### PR TITLE
Show source commit (date, ID, message) on the Downloads and WPT pages

### DIFF
--- a/src/components/commit_info.rs
+++ b/src/components/commit_info.rs
@@ -6,7 +6,7 @@ fn format_commit_date(timestamp: &str) -> String {
     timestamp
         .strip_suffix('Z')
         .and_then(|timestamp| timestamp.split_once('T'))
-        .map(|(date, _time)| format!("{date}"))
+        .map(|(date, _time)| date.to_string())
         .unwrap_or_else(|| timestamp.to_string())
 }
 

--- a/src/components/commit_info.rs
+++ b/src/components/commit_info.rs
@@ -1,0 +1,41 @@
+use dioxus::prelude::*;
+
+use crate::github::CommitInfo;
+
+fn format_commit_date(timestamp: &str) -> String {
+    timestamp
+        .strip_suffix('Z')
+        .and_then(|timestamp| timestamp.split_once('T'))
+        .map(|(date, time)| format!("{date} {} UTC", time))
+        .unwrap_or_else(|| timestamp.to_string())
+}
+
+#[component]
+pub fn CommitInfoDisplay(commit_info: Option<CommitInfo>) -> Element {
+    let Some(commit_info) = commit_info else {
+        return rsx! {};
+    };
+    let short_sha = commit_info.sha.get(..7).unwrap_or(&commit_info.sha);
+    let message = commit_info
+        .message
+        .as_deref()
+        .and_then(|message| message.lines().next());
+
+    rsx! {
+        p {
+            style: "font-size: 0.8em; color: #666;",
+            "Data from "
+            if let Some(timestamp) = commit_info.timestamp.as_deref() {
+                "{format_commit_date(timestamp)} "
+            }
+            a {
+                href: "https://github.com/DioxusLabs/blitz/commit/{commit_info.sha}",
+                target: "_blank",
+                "{short_sha}"
+            }
+            if let Some(message) = message {
+                " — {message}"
+            }
+        }
+    }
+}

--- a/src/components/commit_info.rs
+++ b/src/components/commit_info.rs
@@ -6,7 +6,7 @@ fn format_commit_date(timestamp: &str) -> String {
     timestamp
         .strip_suffix('Z')
         .and_then(|timestamp| timestamp.split_once('T'))
-        .map(|(date, time)| format!("{date} {} UTC", time))
+        .map(|(date, _time)| format!("{date}"))
         .unwrap_or_else(|| timestamp.to_string())
 }
 
@@ -23,18 +23,26 @@ pub fn CommitInfoDisplay(commit_info: Option<CommitInfo>) -> Element {
 
     rsx! {
         p {
-            style: "font-size: 0.8em; color: #666;",
-            "Data from "
-            if let Some(timestamp) = commit_info.timestamp.as_deref() {
-                "{format_commit_date(timestamp)} "
+            // font_size: "smaller",
+            span {
+                font_size: "smaller",
+                color: "#666",
+                "Data from:"
             }
+            br {},
             a {
                 href: "https://github.com/DioxusLabs/blitz/commit/{commit_info.sha}",
                 target: "_blank",
                 "{short_sha}"
             }
             if let Some(message) = message {
-                " — {message}"
+                " {message}"
+            }
+            if let Some(timestamp) = commit_info.timestamp.as_deref() {
+                span {
+                    color: "#666",
+                    " ({format_commit_date(timestamp)})"
+                }
             }
         }
     }

--- a/src/components/commit_info.rs
+++ b/src/components/commit_info.rs
@@ -23,7 +23,6 @@ pub fn CommitInfoDisplay(commit_info: Option<CommitInfo>) -> Element {
 
     rsx! {
         p {
-            // font_size: "smaller",
             span {
                 font_size: "smaller",
                 color: "#666",

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -14,3 +14,6 @@ mod section;
 pub use section::*;
 mod toc;
 pub use toc::*;
+
+mod commit_info;
+pub use commit_info::*;

--- a/src/downloads.rs
+++ b/src/downloads.rs
@@ -7,7 +7,7 @@ use std::{
 
 use tempfile::NamedTempFile;
 
-use crate::github::GithubClient;
+use crate::github::{CommitInfo, GithubClient};
 
 pub static DOWNLOAD_CACHE: DownloadCache = DownloadCache::new();
 
@@ -26,12 +26,18 @@ impl DownloadCache {
         self.0.lock().unwrap()
     }
 
-    pub fn update(&self, etag: Option<Arc<str>>, artifacts: Arc<[DownloadLink]>) {
+    pub fn update(
+        &self,
+        etag: Option<Arc<str>>,
+        artifacts: Arc<[DownloadLink]>,
+        commit_info: Option<CommitInfo>,
+    ) {
         let cached_at = Instant::now();
         *self.0.lock().unwrap() = Some(Arc::new(DownloadCacheEntry {
             etag,
             cached_at,
             artifacts,
+            commit_info,
         }));
     }
 
@@ -44,6 +50,7 @@ impl DownloadCache {
                 cached_at,
                 etag: entry.etag.clone(),
                 artifacts: entry.artifacts.clone(),
+                commit_info: entry.commit_info.clone(),
             }));
         }
     }
@@ -53,6 +60,7 @@ pub struct DownloadCacheEntry {
     pub etag: Option<Arc<str>>,
     pub cached_at: Instant,
     pub artifacts: Arc<[DownloadLink]>,
+    pub commit_info: Option<CommitInfo>,
 }
 
 pub struct DownloadLink {
@@ -79,7 +87,7 @@ pub async fn load_downloads(_etag: Option<Arc<str>>) {
 
     // Request latest WPT report (with etag)
     let token = std::env::var("GITHUB_TOKEN").expect("GITHUB_TOKEN environment variable not found");
-    let client = GithubClient::new(&token);
+    let client = GithubClient::new(Some(&token));
 
     // if let Some(etag) = etag.as_ref() {
     //     builder = builder.header("If-None-Match", &**etag);
@@ -177,7 +185,23 @@ pub async fn load_downloads(_etag: Option<Arc<str>>) {
             .then_with(|| a.arch.cmp(&b.arch))
     });
 
-    DOWNLOAD_CACHE.update(None, Arc::from(artifacts));
+    let commit_info = latest_build_workflow
+        .head_commit
+        .as_ref()
+        .map(|commit| CommitInfo {
+            sha: commit.id.clone(),
+            message: Some(commit.message.clone()),
+            timestamp: commit.timestamp.clone(),
+        })
+        .or_else(|| {
+            Some(CommitInfo {
+                sha: latest_build_workflow.head_sha.clone(),
+                message: None,
+                timestamp: None,
+            })
+        });
+
+    DOWNLOAD_CACHE.update(None, Arc::from(artifacts), commit_info);
 
     println!("New Browser build links processed and cached.");
 }

--- a/src/github.rs
+++ b/src/github.rs
@@ -4,25 +4,27 @@ use serde::{Deserialize, Serialize};
 
 pub struct GithubClient {
     client: Client,
-    auth_header: String,
+    auth_header: Option<String>,
 }
 
 impl GithubClient {
-    pub fn new(token: &str) -> Self {
+    pub fn new(token: Option<&str>) -> Self {
         Self {
             client: Client::new(),
-            auth_header: format!("Bearer {token}"),
+            auth_header: token.map(|token| format!("Bearer {token}")),
         }
     }
 
+    async fn try_get(&self, url: &str) -> Result<reqwest::Response, reqwest::Error> {
+        let mut request = self.client.get(url).header("user-agent", "Blitz website");
+        if let Some(auth_header) = &self.auth_header {
+            request = request.header("authorization", auth_header);
+        }
+        request.send().await
+    }
+
     pub async fn get(&self, url: &str) -> reqwest::Response {
-        self.client
-            .get(url)
-            .header("authorization", &self.auth_header)
-            .header("user-agent", "Blitz website")
-            .send()
-            .await
-            .unwrap()
+        self.try_get(url).await.unwrap()
     }
 
     pub async fn get_bytes(&self, url: &str) -> Bytes {
@@ -37,6 +39,24 @@ impl GithubClient {
             .unwrap()
     }
 
+    pub async fn commit_info(&self, sha: &str) -> Option<CommitInfo> {
+        let response = self
+            .try_get(&format!(
+                "https://api.github.com/repos/dioxuslabs/blitz/commits/{sha}"
+            ))
+            .await
+            .ok()?;
+        if !response.status().is_success() {
+            return None;
+        }
+        let commit: CommitResponse = response.json().await.ok()?;
+        Some(CommitInfo {
+            sha: sha.to_string(),
+            message: Some(commit.commit.message),
+            timestamp: commit.commit.committer.date,
+        })
+    }
+
     #[allow(dead_code)]
     pub async fn list_artifacts(&self, page: usize) -> ArtifactResponse {
         self.get_json::<ArtifactResponse>(&format!(
@@ -46,17 +66,17 @@ impl GithubClient {
     }
 
     pub async fn list_successful_workflows(&self) -> ListWorkflowsResponse {
-        self.get_json::<ListWorkflowsResponse>(&format!(
-            "/repos/dioxuslabs/blitz/actions/runs?per_page=100&status=success"
-        ))
+        self.get_json::<ListWorkflowsResponse>(
+            "/repos/dioxuslabs/blitz/actions/runs?per_page=100&status=success",
+        )
         .await
     }
 
     #[allow(dead_code)]
     pub async fn list_successful_workflows_raw(&self) -> Bytes {
-        self.get_bytes(&format!(
-            "https://api.github.com/repos/dioxuslabs/blitz/actions/runs?per_page=100&status=success"
-        ))
+        self.get_bytes(
+            "https://api.github.com/repos/dioxuslabs/blitz/actions/runs?per_page=100&status=success",
+        )
         .await
     }
 
@@ -115,6 +135,37 @@ pub struct WorkflowRun {
     pub name: String,
     pub head_branch: String,
     pub head_sha: String,
+    pub head_commit: Option<WorkflowCommit>,
     pub status: String,
     pub conclusion: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct WorkflowCommit {
+    pub id: String,
+    pub message: String,
+    pub timestamp: Option<String>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct CommitInfo {
+    pub sha: String,
+    pub message: Option<String>,
+    pub timestamp: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CommitResponse {
+    commit: CommitDetails,
+}
+
+#[derive(Debug, Deserialize)]
+struct CommitDetails {
+    message: String,
+    committer: Committer,
+}
+
+#[derive(Debug, Deserialize)]
+struct Committer {
+    date: Option<String>,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -66,7 +66,7 @@ async fn main() {
                 let Some(cache_entry) = DOWNLOAD_CACHE.get_cloned() else {
                     return Err((
                         StatusCode::INTERNAL_SERVER_ERROR,
-                        format!("Downloads not available"),
+                        "Downloads not available".to_string(),
                     ));
                 };
 
@@ -82,7 +82,7 @@ async fn main() {
                 else {
                     return Err((
                         StatusCode::NOT_FOUND,
-                        format!("Matching artifact not found"),
+                        "Matching artifact not found".to_string(),
                     ));
                 };
 
@@ -124,6 +124,7 @@ async fn main() {
                         let props = WptResultsPageProps {
                             report: entry.report.clone(),
                             scores: entry.scores.clone(),
+                            commit_info: entry.commit_info.clone(),
                         };
                         return dx_route_with_props(WptResultsPage, props).await;
                     } else if cache_age <= Duration::from_mins(30) {
@@ -141,6 +142,7 @@ async fn main() {
                 let props = WptResultsPageProps {
                     report: entry.report.clone(),
                     scores: entry.scores.clone(),
+                    commit_info: entry.commit_info.clone(),
                 };
 
                 dx_route_with_props(WptResultsPage, props).await
@@ -162,6 +164,7 @@ async fn main() {
                     if cache_age <= Duration::from_secs(30) {
                         let props = DownloadsPageProps {
                             links: ArcDownloadLinks(entry.artifacts.clone()),
+                            commit_info: entry.commit_info.clone(),
                         };
                         return dx_route_with_props(DownloadsPage, props).await;
                     } else if cache_age <= Duration::from_mins(30) {
@@ -178,6 +181,7 @@ async fn main() {
                 let entry = DOWNLOAD_CACHE.get_cloned().unwrap();
                 let props = DownloadsPageProps {
                     links: ArcDownloadLinks(entry.artifacts.clone()),
+                    commit_info: entry.commit_info.clone(),
                 };
 
                 dx_route_with_props(DownloadsPage, props).await
@@ -232,7 +236,7 @@ async fn main() {
 }
 
 async fn dx_route_cached(render_fn: fn() -> Element) -> impl IntoResponse {
-    static CACHE: LazyLock<DashMap<usize, Bytes>> = LazyLock::new(|| DashMap::new());
+    static CACHE: LazyLock<DashMap<usize, Bytes>> = LazyLock::new(DashMap::new);
 
     let fn_key = render_fn as *const () as usize;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -66,7 +66,7 @@ async fn main() {
                 let Some(cache_entry) = DOWNLOAD_CACHE.get_cloned() else {
                     return Err((
                         StatusCode::INTERNAL_SERVER_ERROR,
-                        "Downloads not available".to_string(),
+                        format!("Downloads not available"),
                     ));
                 };
 
@@ -82,7 +82,7 @@ async fn main() {
                 else {
                     return Err((
                         StatusCode::NOT_FOUND,
-                        "Matching artifact not found".to_string(),
+                        format!("Matching artifact not found"),
                     ));
                 };
 
@@ -236,7 +236,7 @@ async fn main() {
 }
 
 async fn dx_route_cached(render_fn: fn() -> Element) -> impl IntoResponse {
-    static CACHE: LazyLock<DashMap<usize, Bytes>> = LazyLock::new(DashMap::new);
+    static CACHE: LazyLock<DashMap<usize, Bytes>> = LazyLock::new(|| DashMap::new());
 
     let fn_key = render_fn as *const () as usize;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -66,7 +66,7 @@ async fn main() {
                 let Some(cache_entry) = DOWNLOAD_CACHE.get_cloned() else {
                     return Err((
                         StatusCode::INTERNAL_SERVER_ERROR,
-                        format!("Downloads not available"),
+                        "Downloads not available".to_string(),
                     ));
                 };
 
@@ -82,7 +82,7 @@ async fn main() {
                 else {
                     return Err((
                         StatusCode::NOT_FOUND,
-                        format!("Matching artifact not found"),
+                        "Matching artifact not found".to_string(),
                     ));
                 };
 
@@ -236,7 +236,7 @@ async fn main() {
 }
 
 async fn dx_route_cached(render_fn: fn() -> Element) -> impl IntoResponse {
-    static CACHE: LazyLock<DashMap<usize, Bytes>> = LazyLock::new(|| DashMap::new());
+    static CACHE: LazyLock<DashMap<usize, Bytes>> = LazyLock::new(DashMap::new);
 
     let fn_key = render_fn as *const () as usize;
 

--- a/src/routes/downloads.rs
+++ b/src/routes/downloads.rs
@@ -3,7 +3,11 @@ use std::{ops::Deref, sync::Arc};
 use dioxus::prelude::*;
 use humansize::{format_size, BINARY};
 
-use crate::{components::Page, downloads::DownloadLink};
+use crate::{
+    components::{CommitInfoDisplay, Page},
+    downloads::DownloadLink,
+    github::CommitInfo,
+};
 
 #[derive(Clone)]
 pub struct ArcDownloadLinks(pub Arc<[DownloadLink]>);
@@ -20,7 +24,7 @@ impl Deref for ArcDownloadLinks {
 }
 
 #[component]
-pub fn DownloadsPage(links: ArcDownloadLinks) -> Element {
+pub fn DownloadsPage(links: ArcDownloadLinks, commit_info: Option<CommitInfo>) -> Element {
     rsx! {
         Page { title: "Downloads".into(),
             h1 {
@@ -29,6 +33,7 @@ pub fn DownloadsPage(links: ArcDownloadLinks) -> Element {
             p {
                 dangerous_inner_html: r#"Downloads for the Blitz Browser"#
             }
+            CommitInfoDisplay { commit_info }
             DownloadsTable { links }
         }
     }

--- a/src/routes/support_matrix.rs
+++ b/src/routes/support_matrix.rs
@@ -11,7 +11,7 @@ static CSS_PROPERTIES: GlobalSignal<Vec<PropGroup>> = Signal::global(|| {
     // Load a hashmap of popularity data
     // Source: https://chromestatus.com/data/csspopularity
     let raw_css_popularity: &str = include_str!("../../data/css-popularity.json");
-    let css_popularity: Vec<PropPopularity> = serde_json::from_str(raw_css_popularity).unwrap();
+    let css_popularity: Vec<PropPopularity> = serde_json::from_str(&raw_css_popularity).unwrap();
     let css_popularity: HashMap<String, f64> = css_popularity
         .into_iter()
         .map(|prop| (prop.property_name, prop.day_percentage))
@@ -19,7 +19,7 @@ static CSS_PROPERTIES: GlobalSignal<Vec<PropGroup>> = Signal::global(|| {
 
     // Load crate data
     let raw_css_prop_groups: &str = include_str!("../../data/css-property-groups.json");
-    let mut css_prop_groups: Vec<PropGroup> = serde_json::from_str(raw_css_prop_groups).unwrap();
+    let mut css_prop_groups: Vec<PropGroup> = serde_json::from_str(&raw_css_prop_groups).unwrap();
 
     // Fill in percentages for each entry
     for group in &mut css_prop_groups {
@@ -28,7 +28,7 @@ static CSS_PROPERTIES: GlobalSignal<Vec<PropGroup>> = Signal::global(|| {
                 Some(props) => *props
                     .iter()
                     .filter_map(|prop_name| css_popularity.get(prop_name))
-                    .max_by(|a, b| a.total_cmp(b))
+                    .max_by(|a, b| a.total_cmp(&b))
                     .unwrap_or(&0.0),
                 None => *css_popularity.get(&entry.name).unwrap_or(&0.0),
             }
@@ -125,7 +125,7 @@ pub fn CssSupportPage() -> Element {
 static HTML_EVENTS: GlobalSignal<Vec<PropGroup>> = Signal::global(|| {
     // Load crate data
     let raw_html_event_groups: &str = include_str!("../../data/html-event-groups.json");
-    serde_json5::from_str(raw_html_event_groups).unwrap()
+    serde_json5::from_str(&raw_html_event_groups).unwrap()
 });
 
 #[component]
@@ -149,7 +149,7 @@ pub fn EventSupportPage() -> Element {
 static HTML_ELEMENTS: GlobalSignal<Vec<PropGroup>> = Signal::global(|| {
     // Load crate data
     let raw_html_event_groups: &str = include_str!("../../data/html-element-groups.json");
-    serde_json5::from_str(raw_html_event_groups).unwrap()
+    serde_json5::from_str(&raw_html_event_groups).unwrap()
 });
 
 #[component]

--- a/src/routes/support_matrix.rs
+++ b/src/routes/support_matrix.rs
@@ -11,7 +11,7 @@ static CSS_PROPERTIES: GlobalSignal<Vec<PropGroup>> = Signal::global(|| {
     // Load a hashmap of popularity data
     // Source: https://chromestatus.com/data/csspopularity
     let raw_css_popularity: &str = include_str!("../../data/css-popularity.json");
-    let css_popularity: Vec<PropPopularity> = serde_json::from_str(&raw_css_popularity).unwrap();
+    let css_popularity: Vec<PropPopularity> = serde_json::from_str(raw_css_popularity).unwrap();
     let css_popularity: HashMap<String, f64> = css_popularity
         .into_iter()
         .map(|prop| (prop.property_name, prop.day_percentage))
@@ -19,7 +19,7 @@ static CSS_PROPERTIES: GlobalSignal<Vec<PropGroup>> = Signal::global(|| {
 
     // Load crate data
     let raw_css_prop_groups: &str = include_str!("../../data/css-property-groups.json");
-    let mut css_prop_groups: Vec<PropGroup> = serde_json::from_str(&raw_css_prop_groups).unwrap();
+    let mut css_prop_groups: Vec<PropGroup> = serde_json::from_str(raw_css_prop_groups).unwrap();
 
     // Fill in percentages for each entry
     for group in &mut css_prop_groups {
@@ -28,7 +28,7 @@ static CSS_PROPERTIES: GlobalSignal<Vec<PropGroup>> = Signal::global(|| {
                 Some(props) => *props
                     .iter()
                     .filter_map(|prop_name| css_popularity.get(prop_name))
-                    .max_by(|a, b| a.total_cmp(&b))
+                    .max_by(|a, b| a.total_cmp(b))
                     .unwrap_or(&0.0),
                 None => *css_popularity.get(&entry.name).unwrap_or(&0.0),
             }
@@ -125,7 +125,7 @@ pub fn CssSupportPage() -> Element {
 static HTML_EVENTS: GlobalSignal<Vec<PropGroup>> = Signal::global(|| {
     // Load crate data
     let raw_html_event_groups: &str = include_str!("../../data/html-event-groups.json");
-    serde_json5::from_str(&raw_html_event_groups).unwrap()
+    serde_json5::from_str(raw_html_event_groups).unwrap()
 });
 
 #[component]
@@ -149,7 +149,7 @@ pub fn EventSupportPage() -> Element {
 static HTML_ELEMENTS: GlobalSignal<Vec<PropGroup>> = Signal::global(|| {
     // Load crate data
     let raw_html_event_groups: &str = include_str!("../../data/html-element-groups.json");
-    serde_json5::from_str(&raw_html_event_groups).unwrap()
+    serde_json5::from_str(raw_html_event_groups).unwrap()
 });
 
 #[component]

--- a/src/routes/wpt.rs
+++ b/src/routes/wpt.rs
@@ -85,6 +85,7 @@ pub fn WptResultsPage(
                 and percentages are relative to the number of tests run.
                 "
             }
+            hr {}
             CommitInfoDisplay { commit_info }
             WptResults { scores }
         }

--- a/src/routes/wpt.rs
+++ b/src/routes/wpt.rs
@@ -4,7 +4,8 @@ use dioxus::prelude::*;
 use wptreport::{wpt_report::WptReport, AreaScores};
 
 use crate::{
-    components::Page,
+    components::{CommitInfoDisplay, Page},
+    github::CommitInfo,
     routes::{StatusHeader, StatusTabs},
 };
 
@@ -65,7 +66,11 @@ impl Deref for ArcWptScores {
 }
 
 #[component]
-pub fn WptResultsPage(report: ArcWptReport, scores: ArcWptScores) -> Element {
+pub fn WptResultsPage(
+    report: ArcWptReport,
+    scores: ArcWptScores,
+    commit_info: Option<CommitInfo>,
+) -> Element {
     rsx! {
         Page { title: "Status: WPT".into(),
             StatusHeader {}
@@ -80,6 +85,7 @@ pub fn WptResultsPage(report: ArcWptReport, scores: ArcWptScores) -> Element {
                 and percentages are relative to the number of tests run.
                 "
             }
+            CommitInfoDisplay { commit_info }
             WptResults { scores }
         }
     }

--- a/src/wpt.rs
+++ b/src/wpt.rs
@@ -10,6 +10,7 @@ use wptreport::{
     wpt_report::{TestStatus, WptReport},
 };
 
+use crate::github::{CommitInfo, GithubClient};
 use crate::routes::{ArcWptReport, ArcWptScores};
 
 pub static WPT_REPORT_CACHE: WptReportCache = WptReportCache::new();
@@ -29,13 +30,20 @@ impl WptReportCache {
         self.0.lock().unwrap()
     }
 
-    pub fn update(&self, etag: Option<Arc<str>>, report: ArcWptReport, scores: ArcWptScores) {
+    pub fn update(
+        &self,
+        etag: Option<Arc<str>>,
+        report: ArcWptReport,
+        scores: ArcWptScores,
+        commit_info: Option<CommitInfo>,
+    ) {
         let cached_at = Instant::now();
         *self.0.lock().unwrap() = Some(Arc::new(WptReportCacheEntry {
             etag,
             cached_at,
             report,
             scores,
+            commit_info,
         }));
     }
 
@@ -48,6 +56,7 @@ impl WptReportCache {
                 etag: entry.etag.clone(),
                 report: entry.report.clone(),
                 scores: entry.scores.clone(),
+                commit_info: entry.commit_info.clone(),
             }));
         }
     }
@@ -58,6 +67,7 @@ pub struct WptReportCacheEntry {
     pub cached_at: Instant,
     pub report: ArcWptReport,
     pub scores: ArcWptScores,
+    pub commit_info: Option<CommitInfo>,
 }
 
 pub async fn load_wpt_results(etag: Option<Arc<str>>) {
@@ -82,7 +92,7 @@ pub async fn load_wpt_results(etag: Option<Arc<str>>) {
         .headers()
         .get("etag")
         .and_then(|header| header.to_str().ok())
-        .map(|s| Arc::from(s));
+        .map(Arc::from);
 
     println!("New WPT results found. etag: {etag:?}");
 
@@ -90,6 +100,26 @@ pub async fn load_wpt_results(etag: Option<Arc<str>>) {
 
     let uncompressed_report = zstd::decode_all(Cursor::new(&compressed_report)).unwrap();
     let mut report: WptReport = serde_json::from_slice(&uncompressed_report).unwrap();
+    let commit_info = report
+        .run_info
+        .browser_version
+        .clone()
+        .map(|sha| CommitInfo {
+            sha: sha.clone(),
+            message: None,
+            timestamp: None,
+        });
+
+    let commit_info = if let Some(mut commit_info) = commit_info {
+        let github_client = GithubClient::new(None);
+        if let Some(github_commit) = github_client.commit_info(&commit_info.sha).await {
+            commit_info.message = github_commit.message;
+            commit_info.timestamp = github_commit.timestamp;
+        }
+        Some(commit_info)
+    } else {
+        None
+    };
 
     // Strip skipped tests
     report
@@ -101,7 +131,7 @@ pub async fn load_wpt_results(etag: Option<Arc<str>>) {
     let report = ArcWptReport(Arc::new(report));
     let scores = ArcWptScores(Arc::new(scores));
 
-    WPT_REPORT_CACHE.update(etag, report.clone(), scores.clone());
+    WPT_REPORT_CACHE.update(etag, report.clone(), scores.clone(), commit_info);
 
     println!("New WPT results processed and cached.");
 }

--- a/src/wpt.rs
+++ b/src/wpt.rs
@@ -111,7 +111,7 @@ pub async fn load_wpt_results(etag: Option<Arc<str>>) {
         });
 
     let commit_info = if let Some(mut commit_info) = commit_info {
-        let github_client = GithubClient::new(None);
+        let github_client = GithubClient::new(std::env::var("GITHUB_TOKEN").ok().as_deref());
         if let Some(github_commit) = github_client.commit_info(&commit_info.sha).await {
             commit_info.message = github_commit.message;
             commit_info.timestamp = github_commit.timestamp;


### PR DESCRIPTION
## Summary

Both data-driven pages now show which blitz commit the displayed data came from, via a shared `CommitInfoDisplay` component (date, short SHA linked to the commit on GitHub, first line of the commit message). The info is stored as `Option<CommitInfo>` on the two cache entries and passed through the page props.

Where the commit comes from differs per page:
- **Downloads**: the Actions run JSON already carries `head_commit { id, message, timestamp }`, so `WorkflowRun` just gained that field — no extra API request. Falls back to `head_sha` alone if absent.
- **WPT**: the report's `run_info.browser_version` is the blitz SHA the run was built from (`run_info.revision` is the *WPT* repo revision, not what we want), so the message/date require a `/repos/dioxuslabs/blitz/commits/{sha}` lookup. That lookup is entirely fallible — any network/status/parse failure leaves message and date as `None` and the page still renders with the SHA. `GithubClient` therefore accepts an optional token (`GithubClient::new(std::env::var("GITHUB_TOKEN").ok().as_deref())`) and omits the auth header when there isn't one, since the WPT path isn't guaranteed a token.

Dates are formatted from ISO 8601 to `YYYY-MM-DD HH:MM:SS UTC` with a fallback to the raw string; no new dependency.

Verified locally by running the server with `GITHUB_TOKEN` unset and requesting `/status/wpt`:

```
Data from 2026-08-02 12:56:33 UTC
ed82c16 — Remove `incremental` feature flag (add runtime setting to `DocumentConfig`) (#599)
```

The Downloads page couldn't be exercised locally (requires `GITHUB_TOKEN`).


Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/6d7a78c9359b487c958ae672eb9d644e
Requested by: @nicoburns