### PR TITLE
Add drill-down pages for WPT status areas

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 use axum::{
     body::{Body, Bytes},
-    extract::Query,
+    extract::{Path, Query},
     http::{header, StatusCode},
     response::{AppendHeaders, Html, IntoResponse, Redirect},
     routing::{get, get_service},
@@ -112,40 +112,35 @@ async fn main() {
         .route(
             "/status/wpt",
             get(async || {
-                let now = Instant::now();
-                let cache_entry = WPT_REPORT_CACHE.get_cloned();
-                let etag = cache_entry.as_ref().and_then(|entry| entry.etag.clone());
-
-                // Cache with 30s validity
-                let mut await_revalidation = true;
-                if let Some(entry) = &cache_entry {
-                    let cache_age = now.duration_since(entry.cached_at);
-                    if cache_age <= Duration::from_secs(30) {
-                        let props = WptResultsPageProps {
-                            report: entry.report.clone(),
-                            scores: entry.scores.clone(),
-                            commit_info: entry.commit_info.clone(),
-                        };
-                        return dx_route_with_props(WptResultsPage, props).await;
-                    } else if cache_age <= Duration::from_mins(30) {
-                        await_revalidation = false
-                    }
-                }
-
-                let handle = tokio::spawn(async move { load_wpt_results(etag).await });
-
-                if await_revalidation {
-                    handle.await.unwrap();
-                }
-
-                let entry = WPT_REPORT_CACHE.get_cloned().unwrap();
+                let entry = fresh_wpt_cache_entry().await;
                 let props = WptResultsPageProps {
                     report: entry.report.clone(),
                     scores: entry.scores.clone(),
                     commit_info: entry.commit_info.clone(),
+                    area: None,
                 };
 
                 dx_route_with_props(WptResultsPage, props).await
+            }),
+        )
+        .route(
+            "/status/wpt/{*area}",
+            get(async |Path(area): Path<String>| {
+                let area = area.trim_matches('/').to_string();
+                let entry = fresh_wpt_cache_entry().await;
+
+                if !entry.scores.contains_key(&area) {
+                    return Err((StatusCode::NOT_FOUND, format!("Unknown WPT area: {area}")));
+                }
+
+                let props = WptResultsPageProps {
+                    report: entry.report.clone(),
+                    scores: entry.scores.clone(),
+                    commit_info: entry.commit_info.clone(),
+                    area: Some(area),
+                };
+
+                Ok(dx_route_with_props(WptResultsPage, props).await)
             }),
         )
         .route(
@@ -233,6 +228,34 @@ async fn main() {
     axum::serve(listener, app.into_make_service())
         .await
         .unwrap();
+}
+
+/// Get the cached WPT report, revalidating it if it is stale.
+/// Revalidation is awaited if the cache is more than 30 minutes old,
+/// and performed in the background if it is between 30 seconds and 30 minutes old.
+async fn fresh_wpt_cache_entry() -> std::sync::Arc<wpt::WptReportCacheEntry> {
+    let now = Instant::now();
+    let cache_entry = WPT_REPORT_CACHE.get_cloned();
+    let etag = cache_entry.as_ref().and_then(|entry| entry.etag.clone());
+
+    // Cache with 30s validity
+    let mut await_revalidation = true;
+    if let Some(entry) = cache_entry {
+        let cache_age = now.duration_since(entry.cached_at);
+        if cache_age <= Duration::from_secs(30) {
+            return entry;
+        } else if cache_age <= Duration::from_mins(30) {
+            await_revalidation = false
+        }
+    }
+
+    let handle = tokio::spawn(async move { load_wpt_results(etag).await });
+
+    if await_revalidation {
+        handle.await.unwrap();
+    }
+
+    WPT_REPORT_CACHE.get_cloned().unwrap()
 }
 
 async fn dx_route_cached(render_fn: fn() -> Element) -> impl IntoResponse {

--- a/src/routes/wpt.rs
+++ b/src/routes/wpt.rs
@@ -1,7 +1,10 @@
 use std::{collections::BTreeMap, ops::Deref, sync::Arc};
 
 use dioxus::prelude::*;
-use wptreport::{wpt_report::WptReport, AreaScores};
+use wptreport::{
+    wpt_report::{TestResult, TestStatus, WptReport},
+    AreaScores, SubtestCounts, TestResultIter,
+};
 
 use crate::{
     components::{CommitInfoDisplay, Page},
@@ -70,6 +73,7 @@ pub fn WptResultsPage(
     report: ArcWptReport,
     scores: ArcWptScores,
     commit_info: Option<CommitInfo>,
+    area: Option<String>,
 ) -> Element {
     rsx! {
         Page { title: "Status: WPT".into(),
@@ -87,14 +91,19 @@ pub fn WptResultsPage(
             }
             hr {}
             CommitInfoDisplay { commit_info, label: "Data from commit:" }
-            WptResults { scores }
+            if let Some(area) = area {
+                WptBreadcrumb { area: area.clone() }
+                WptAreaResults { report, scores, area }
+            } else {
+                WptResults { scores }
+            }
         }
     }
 }
 
 fn is_focus_area(area: &str) -> bool {
     let slash_count = area.chars().filter(|c| *c == '/').count();
-    slash_count < 2 || (slash_count == 2 && area.starts_with("css/CSS2"))
+    slash_count < 2
 }
 
 #[component]
@@ -112,42 +121,163 @@ pub fn WptResults(scores: ArcWptScores) -> Element {
             }
             {
                 scores.iter().filter(|(area, _)| is_focus_area(area)).map(|(area, scores)| {
-
-                    let tests = scores.tests;
-                    let subtests = scores.subtests;
-
-                    let color = COLORS.get(subtests.pass_fraction() as f32);
-
-                    rsx!(
-                        tr {
-                            background_color: format!("rgb({},{},{})", color[0], color[1], color[2]),
-                            td {
-                                background_color: "white",
-                                {area.clone()}
-                            }
-                            td {
-                                text_align: "right",
-                                {format!("{:.2}%", (scores.interop_score() as f32 / 1000.0) * 100.0)}
-                            }
-                            td {
-                                text_align: "right",
-                                {format!("({}/{})", tests.pass, tests.total)}
-                            }
-                            td {
-                                text_align: "right",
-                                {format!("{:.2}%", tests.pass_fraction() * 100.0)}
-                            }
-                            td {
-                                text_align: "right",
-                                {format!("({}/{})", subtests.pass, subtests.total)}
-                            }
-                            td {
-                                text_align: "right",
-                                {format!("{:.2}%", subtests.pass_fraction() * 100.0)}
-                            }
-                        }
-                    )
+                    area_score_row(area.clone(), Some(format!("/status/wpt/{area}")), *scores)
                 })
+            }
+        }
+    )
+}
+
+#[component]
+pub fn WptBreadcrumb(area: String) -> Element {
+    let mut prefix = String::new();
+    let segments: Vec<(String, String)> = area
+        .split('/')
+        .map(|segment| {
+            if !prefix.is_empty() {
+                prefix.push('/');
+            }
+            prefix.push_str(segment);
+            (segment.to_string(), format!("/status/wpt/{prefix}"))
+        })
+        .collect();
+
+    rsx!(
+        p {
+            a { href: "/status/wpt", "wpt" }
+            for (segment, href) in segments {
+                " / "
+                a { href, {segment} }
+            }
+        }
+    )
+}
+
+#[component]
+pub fn WptAreaResults(report: ArcWptReport, scores: ArcWptScores, area: String) -> Element {
+    let child_prefix = format!("{area}/");
+    let child_areas: Vec<(&String, &AreaScores)> = scores
+        .iter()
+        .filter(|(key, _)| {
+            key.starts_with(&child_prefix) && !key[child_prefix.len()..].contains('/')
+        })
+        .collect();
+
+    let tests: Vec<&TestResult> = report
+        .results
+        .iter()
+        .filter(|test| {
+            test.test
+                .rsplit_once('/')
+                .map(|(dir, _)| dir == area)
+                .unwrap_or(false)
+        })
+        .collect();
+
+    let area_scores = scores.get(&area).copied().unwrap_or_default();
+
+    rsx!(
+        table {
+            width: "100%",
+            tr {
+                th { width: "min-content", "Area",  }
+                th { "Interop Score", }
+                th { "Tests", }
+                th { "Test %", }
+                th { "Subtests" }
+                th { "Subtest %" }
+            }
+            {area_score_row("Total".to_string(), None, area_scores)}
+            for (key, scores) in child_areas {
+                {area_score_row(
+                    key[child_prefix.len()..].to_string(),
+                    Some(format!("/status/wpt/{key}")),
+                    *scores,
+                )}
+            }
+        }
+        if !tests.is_empty() {
+            table {
+                width: "100%",
+                margin_top: "24px",
+                tr {
+                    th { width: "min-content", "Test",  }
+                    th { "Status", }
+                    th { "Subtests" }
+                    th { "Subtest %" }
+                }
+                for test in tests {
+                    TestScoreRow { name: test.test.clone(), status: test.status, counts: test.subtest_counts() }
+                }
+            }
+        }
+    )
+}
+
+fn area_score_row(label: String, href: Option<String>, scores: AreaScores) -> Element {
+    let tests = scores.tests;
+    let subtests = scores.subtests;
+
+    let color = COLORS.get(subtests.pass_fraction() as f32);
+
+    rsx!(
+        tr {
+            background_color: format!("rgb({},{},{})", color[0], color[1], color[2]),
+            td {
+                background_color: "white",
+                if let Some(href) = href {
+                    a { href, {label} }
+                } else {
+                    {label}
+                }
+            }
+            td {
+                text_align: "right",
+                {format!("{:.2}%", (scores.interop_score() as f32 / 1000.0) * 100.0)}
+            }
+            td {
+                text_align: "right",
+                {format!("({}/{})", tests.pass, tests.total)}
+            }
+            td {
+                text_align: "right",
+                {format!("{:.2}%", tests.pass_fraction() * 100.0)}
+            }
+            td {
+                text_align: "right",
+                {format!("({}/{})", subtests.pass, subtests.total)}
+            }
+            td {
+                text_align: "right",
+                {format!("{:.2}%", subtests.pass_fraction() * 100.0)}
+            }
+        }
+    )
+}
+
+#[component]
+fn TestScoreRow(name: String, status: TestStatus, counts: SubtestCounts) -> Element {
+    let color = COLORS.get(counts.pass_fraction() as f32);
+    let file_name = name.rsplit_once('/').map(|(_, file)| file).unwrap_or(&name);
+
+    rsx!(
+        tr {
+            background_color: format!("rgb({},{},{})", color[0], color[1], color[2]),
+            td {
+                background_color: "white",
+                {file_name.to_string()}
+            }
+            td {
+                text_align: "right",
+                {format!("{status:?}").to_uppercase()}
+            }
+            td {
+                text_align: "right",
+                {format!("({}/{})", counts.pass, counts.total)}
+            }
+            td {
+                text_align: "right",
+                {format!("{:.2}%", counts.pass_fraction() * 100.0)}
             }
         }
     )

--- a/src/routes/wpt.rs
+++ b/src/routes/wpt.rs
@@ -265,7 +265,11 @@ fn TestScoreRow(name: String, status: TestStatus, counts: SubtestCounts) -> Elem
             background_color: format!("rgb({},{},{})", color[0], color[1], color[2]),
             td {
                 background_color: "white",
-                {file_name.to_string()}
+                a {
+                    href: format!("https://wpt.live/{name}"),
+                    target: "_blank",
+                    {file_name.to_string()}
+                }
             }
             td {
                 text_align: "right",

--- a/src/routes/wpt.rs
+++ b/src/routes/wpt.rs
@@ -202,9 +202,9 @@ pub fn WptAreaResults(report: ArcWptReport, scores: ArcWptScores, area: String) 
                 margin_top: "24px",
                 tr {
                     th { width: "min-content", "Test",  }
-                    th { "Status", }
                     th { "Subtests" }
                     th { "Subtest %" }
+                    th { "Status", }
                 }
                 for test in tests {
                     TestScoreRow { name: test.test.clone(), status: test.status, counts: test.subtest_counts() }
@@ -269,15 +269,15 @@ fn TestScoreRow(name: String, status: TestStatus, counts: SubtestCounts) -> Elem
             }
             td {
                 text_align: "right",
-                {format!("{status:?}").to_uppercase()}
-            }
-            td {
-                text_align: "right",
                 {format!("({}/{})", counts.pass, counts.total)}
             }
             td {
                 text_align: "right",
                 {format!("{:.2}%", counts.pass_fraction() * 100.0)}
+            }
+            td {
+                text_align: "right",
+                {format!("{status:?}").to_uppercase()}
             }
         }
     )


### PR DESCRIPTION
## Summary

Adds wpt.fyi-style drill-down to the WPT status section. Every area name in the results table is now a link to `/status/wpt/{*area}`, which renders:

- a breadcrumb (`wpt / css / CSS2 / abspos`, each segment linked)
- a "Total" row for the area plus one row per direct child area (scores for all area prefixes were already computed by `score_wpt_report`; the top-level page just filtered them out)
- a table of individual tests directly in that directory (name, status, subtest counts/%), sourced from the full `WptReport` already cached in memory

The CSS2 special-casing in `is_focus_area` is removed — the top-level page now uniformly shows areas up to one segment deep, and CSS2's subcategories are reached via drill-down at `/status/wpt/css/CSS2`.

Unknown areas return 404. The cache/revalidation logic previously inlined in the `/status/wpt` handler is factored into `fresh_wpt_cache_entry()` and shared by both routes.

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/d0a6135768c64e92a7bb9c54af8199b5
Requested by: @nicoburns