### PR TITLE
Add (source) link next to WPT test names

### DIFF
--- a/src/routes/wpt.rs
+++ b/src/routes/wpt.rs
@@ -270,12 +270,15 @@ fn TestScoreRow(name: String, status: TestStatus, counts: SubtestCounts) -> Elem
                     target: "_blank",
                     {file_name.to_string()}
                 }
-                " "
-                a {
-                    href: format!("view-source:https://wpt.live/{name}"),
-                    target: "_blank",
+                span {
                     font_size: "smaller",
-                    "(source)"
+                    " ("
+                    a {
+                        href: format!("view-source:https://wpt.live/{name}"),
+                        target: "_blank",
+                        "source"
+                    }
+                    ")"
                 }
             }
             td {

--- a/src/routes/wpt.rs
+++ b/src/routes/wpt.rs
@@ -270,6 +270,13 @@ fn TestScoreRow(name: String, status: TestStatus, counts: SubtestCounts) -> Elem
                     target: "_blank",
                     {file_name.to_string()}
                 }
+                " "
+                a {
+                    href: format!("view-source:https://wpt.live/{name}"),
+                    target: "_blank",
+                    font_size: "smaller",
+                    "(source)"
+                }
             }
             td {
                 text_align: "right",


### PR DESCRIPTION
## Summary

Each test row in the WPT status page now has a small `(source)` link after the test name, pointing at `view-source:https://wpt.live/{test}` so the test's HTML can be inspected directly.

Note: Chrome and Firefox block navigation to `view-source:` URLs from a web page, so the link only works via copy-link / middle-click paste into the address bar in those browsers.

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/8f04a37fc5944cc58a39873550276275
Requested by: @nicoburns