### PR TITLE
Add WPT history chart page

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -21,7 +21,7 @@ use downloads::{load_downloads, DOWNLOAD_CACHE};
 use routes::{
     AboutPage, ArcDownloadLinks, CssSupportPage, DownloadsPage, DownloadsPageProps,
     ElementSupportPage, EventSupportPage, GettingStartedPage, HomePage, NLNetInstructionsPage,
-    WptResultsPage, WptResultsPageProps,
+    WptHistoryPage, WptHistoryPageProps, WptResultsPage, WptResultsPageProps,
 };
 use serde::Deserialize;
 use std::{
@@ -32,12 +32,14 @@ use std::{
 use tokio::net::TcpListener;
 use tower_http::{services::ServeDir, trace::TraceLayer};
 use wpt::{load_wpt_results, WPT_REPORT_CACHE};
+use wpt_history::{load_wpt_history, WPT_HISTORY_CACHE};
 
 mod components;
 mod downloads;
 mod github;
 mod routes;
 mod wpt;
+mod wpt_history;
 
 #[derive(Deserialize)]
 struct DownloadLinkKey {
@@ -146,6 +148,41 @@ async fn main() {
                 };
 
                 dx_route_with_props(WptResultsPage, props).await
+            }),
+        )
+        .route(
+            "/status/wpt/history",
+            get(async || {
+                let now = Instant::now();
+                let cache_entry = WPT_HISTORY_CACHE.get_cloned();
+                let etag = cache_entry.as_ref().and_then(|entry| entry.etag.clone());
+
+                // Cache with 30s validity
+                let mut await_revalidation = true;
+                if let Some(entry) = &cache_entry {
+                    let cache_age = now.duration_since(entry.cached_at);
+                    if cache_age <= Duration::from_secs(30) {
+                        let props = WptHistoryPageProps {
+                            summary: entry.summary.clone(),
+                        };
+                        return dx_route_with_props(WptHistoryPage, props).await;
+                    } else if cache_age <= Duration::from_mins(30) {
+                        await_revalidation = false
+                    }
+                }
+
+                let handle = tokio::spawn(async move { load_wpt_history(etag).await });
+
+                if await_revalidation {
+                    handle.await.unwrap();
+                }
+
+                let entry = WPT_HISTORY_CACHE.get_cloned().unwrap();
+                let props = WptHistoryPageProps {
+                    summary: entry.summary.clone(),
+                };
+
+                dx_route_with_props(WptHistoryPage, props).await
             }),
         )
         .route(

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,7 +19,7 @@ use dioxus::{core::ComponentFunction, prelude::*};
 use dioxus_html_macro::html;
 use downloads::{load_downloads, DOWNLOAD_CACHE};
 use routes::{
-    AboutPage, ArcDownloadLinks, CssSupportPage, DownloadsPage, DownloadsPageProps,
+    AboutPage, ArcDownloadLinks, ChartRange, CssSupportPage, DownloadsPage, DownloadsPageProps,
     ElementSupportPage, EventSupportPage, GettingStartedPage, HomePage, NLNetInstructionsPage,
     WptHistoryPage, WptHistoryPageProps, WptResultsPage, WptResultsPageProps,
 };
@@ -40,6 +40,11 @@ mod github;
 mod routes;
 mod wpt;
 mod wpt_history;
+
+#[derive(Deserialize)]
+struct WptHistoryQuery {
+    range: Option<String>,
+}
 
 #[derive(Deserialize)]
 struct DownloadLinkKey {
@@ -152,7 +157,8 @@ async fn main() {
         )
         .route(
             "/status/wpt/history",
-            get(async || {
+            get(async |query: Query<WptHistoryQuery>| {
+                let range = ChartRange::from_query(query.range.as_deref());
                 let now = Instant::now();
                 let cache_entry = WPT_HISTORY_CACHE.get_cloned();
                 let etag = cache_entry.as_ref().and_then(|entry| entry.etag.clone());
@@ -164,6 +170,7 @@ async fn main() {
                     if cache_age <= Duration::from_secs(30) {
                         let props = WptHistoryPageProps {
                             summary: entry.summary.clone(),
+                            range,
                         };
                         return dx_route_with_props(WptHistoryPage, props).await;
                     } else if cache_age <= Duration::from_mins(30) {
@@ -180,6 +187,7 @@ async fn main() {
                 let entry = WPT_HISTORY_CACHE.get_cloned().unwrap();
                 let props = WptHistoryPageProps {
                     summary: entry.summary.clone(),
+                    range,
                 };
 
                 dx_route_with_props(WptHistoryPage, props).await

--- a/src/main.rs
+++ b/src/main.rs
@@ -171,6 +171,7 @@ async fn main() {
                         let props = WptHistoryPageProps {
                             summary: entry.summary.clone(),
                             range,
+                            commit_messages: entry.commit_messages.clone(),
                         };
                         return dx_route_with_props(WptHistoryPage, props).await;
                     } else if cache_age <= Duration::from_mins(30) {
@@ -188,6 +189,7 @@ async fn main() {
                 let props = WptHistoryPageProps {
                     summary: entry.summary.clone(),
                     range,
+                    commit_messages: entry.commit_messages.clone(),
                 };
 
                 dx_route_with_props(WptHistoryPage, props).await

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -6,3 +6,4 @@ mod downloads;          pub use downloads::*;
 mod about;              pub use about::*;
 mod nlnet_instructions; pub use nlnet_instructions::*;
 mod wpt;                pub use wpt::*;
+mod wpt_history;        pub use wpt_history::*;

--- a/src/routes/support_matrix.rs
+++ b/src/routes/support_matrix.rs
@@ -63,6 +63,10 @@ pub fn StatusTabs(current_tab: &'static str) -> Element {
             href: "/status/wpt",
             label: "WPT Tests",
         },
+        Tab {
+            href: "/status/wpt/history",
+            label: "WPT History",
+        },
     ];
 
     rsx!(

--- a/src/routes/wpt_history.rs
+++ b/src/routes/wpt_history.rs
@@ -85,6 +85,7 @@ const MONTH_NAMES: [&str; 12] = [
 
 #[derive(Copy, Clone, PartialEq, Debug, Default)]
 pub enum ChartRange {
+    Month1,
     Months3,
     Months6,
     Year1,
@@ -93,7 +94,8 @@ pub enum ChartRange {
 }
 
 impl ChartRange {
-    pub const ALL: [ChartRange; 4] = [
+    pub const ALL: [ChartRange; 5] = [
+        ChartRange::Month1,
         ChartRange::Months3,
         ChartRange::Months6,
         ChartRange::Year1,
@@ -102,6 +104,7 @@ impl ChartRange {
 
     pub fn from_query(value: Option<&str>) -> Self {
         match value {
+            Some("1m") => ChartRange::Month1,
             Some("3m") => ChartRange::Months3,
             Some("6m") => ChartRange::Months6,
             Some("1y") => ChartRange::Year1,
@@ -111,6 +114,7 @@ impl ChartRange {
 
     fn query_value(self) -> &'static str {
         match self {
+            ChartRange::Month1 => "1m",
             ChartRange::Months3 => "3m",
             ChartRange::Months6 => "6m",
             ChartRange::Year1 => "1y",
@@ -120,6 +124,7 @@ impl ChartRange {
 
     fn label(self) -> &'static str {
         match self {
+            ChartRange::Month1 => "1 month",
             ChartRange::Months3 => "3 months",
             ChartRange::Months6 => "6 months",
             ChartRange::Year1 => "1 year",
@@ -129,6 +134,7 @@ impl ChartRange {
 
     fn days(self) -> Option<f64> {
         match self {
+            ChartRange::Month1 => Some(30.0),
             ChartRange::Months3 => Some(91.0),
             ChartRange::Months6 => Some(183.0),
             ChartRange::Year1 => Some(365.0),
@@ -339,13 +345,14 @@ const TOOLTIP_JS: &str = r##"
         return s.replace(/&/g, "&amp;").replace(/</g, "&lt;");
     }
 
+    // Nearest hoverable run (runs before data.first only serve as deltas)
     function nearest(x) {
-        var runs = data.runs, lo = 0, hi = runs.length - 1;
+        var runs = data.runs, lo = data.first, hi = runs.length - 1;
         while (lo < hi) {
             var mid = (lo + hi) >> 1;
             if (runs[mid].x < x) lo = mid + 1; else hi = mid;
         }
-        if (lo > 0 && Math.abs(runs[lo - 1].x - x) < Math.abs(runs[lo].x - x)) lo--;
+        if (lo > data.first && Math.abs(runs[lo - 1].x - x) < Math.abs(runs[lo].x - x)) lo--;
         return lo;
     }
 
@@ -367,7 +374,9 @@ const TOOLTIP_JS: &str = r##"
         if (vx < px || vx > px + pw) { hide(); return; }
 
         var xRange = data.xMax - data.xMin;
-        var run = data.runs[nearest(data.xMin + ((vx - px) / pw) * xRange)];
+        var runIdx = nearest(data.xMin + ((vx - px) / pw) * xRange);
+        var run = data.runs[runIdx];
+        var prev = runIdx > 0 ? data.runs[runIdx - 1] : null;
 
         // Pick the single series whose line is vertically nearest the cursor
         var best = -1, bestDist = Y_THRESHOLD;
@@ -393,6 +402,16 @@ const TOOLTIP_JS: &str = r##"
         html += "<div><span style='color:" + data.series[best].color + "'>\u25CF</span> " +
             esc(data.series[best].name) + ": " + (100 * pass / total).toFixed(1) + "% (" +
             pass.toLocaleString() + "/" + total.toLocaleString() + ")</div>";
+
+        // Change relative to the previous run
+        if (prev && prev.v[best] != null) {
+            var dPass = pass - prev.v[best][0];
+            var dPct = 100 * (pass / total - prev.v[best][0] / prev.v[best][1]);
+            var sign = dPass > 0 ? "+" : "";
+            var color = dPass > 0 ? "#2e7d32" : (dPass < 0 ? "#c62828" : "#666");
+            html += "<div style='color:" + color + "'>\u0394 vs prev: " + sign +
+                dPass.toLocaleString() + " (" + sign + dPct.toFixed(2) + "pp)</div>";
+        }
         tip.innerHTML = html;
         tip.style.display = "block";
 
@@ -445,14 +464,18 @@ pub fn WptHistoryChart(
         .iter()
         .map(|(area, _)| summary.focus_areas.iter().position(|a| a == area))
         .collect();
-    let runs_json: Vec<serde_json::Value> = summary
+    // Include the run immediately before the visible range (if any) so the
+    // first visible run's tooltip can show a delta against it
+    let first_visible = summary
         .runs
+        .iter()
+        .position(|run| parse_date(&run.date).is_some_and(|x| x >= min_x))
+        .unwrap_or(0);
+    let start = first_visible.saturating_sub(1);
+    let runs_json: Vec<serde_json::Value> = summary.runs[start..]
         .iter()
         .filter_map(|run| {
             let x = parse_date(&run.date)?;
-            if x < min_x {
-                return None;
-            }
             let values: Vec<serde_json::Value> = area_indices
                 .iter()
                 .map(|idx| {
@@ -477,6 +500,7 @@ pub fn WptHistoryChart(
         })
         .collect();
     let tooltip_data = serde_json::json!({
+        "first": first_visible - start,
         "width": WIDTH,
         "plot": [px, py, pw, ph],
         "xMin": x_min,

--- a/src/routes/wpt_history.rs
+++ b/src/routes/wpt_history.rs
@@ -324,7 +324,7 @@ const TOOLTIP_JS: &str = r##"
     tip.style.cssText =
         "position:absolute;pointer-events:none;display:none;background:rgba(255,255,255,0.96);" +
         "border:1px solid #999;border-radius:4px;padding:6px 8px;font:12px sans-serif;" +
-        "box-shadow:0 1px 4px rgba(0,0,0,0.25);z-index:10;max-width:340px";
+        "box-shadow:0 1px 4px rgba(0,0,0,0.25);z-index:10;width:260px;box-sizing:border-box";
     container.appendChild(tip);
 
     var guide = document.createElementNS("http://www.w3.org/2000/svg", "line");
@@ -369,7 +369,10 @@ const TOOLTIP_JS: &str = r##"
         guide.style.display = "";
 
         var html = "<div style='font-weight:bold'>" + esc(run.sha.slice(0, 9)) + " (" + esc(run.d) + ")</div>";
-        if (run.msg) html += "<div style='margin-bottom:4px'>" + esc(run.msg) + "</div>";
+        if (run.msg) {
+            html += "<div style='margin-bottom:4px;white-space:nowrap;overflow:hidden;" +
+                "text-overflow:ellipsis'>" + esc(run.msg) + "</div>";
+        }
         for (var i = 0; i < data.series.length; i++) {
             if (run.v[i] == null) continue;
             html += "<div><span style='color:" + data.series[i].color + "'>\u25CF</span> " +

--- a/src/routes/wpt_history.rs
+++ b/src/routes/wpt_history.rs
@@ -7,6 +7,20 @@ use crate::routes::{StatusHeader, StatusTabs};
 use crate::components::Page;
 
 #[derive(Clone)]
+pub struct ArcCommitMessages(pub Arc<std::collections::HashMap<String, String>>);
+impl PartialEq for ArcCommitMessages {
+    fn eq(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.0, &other.0)
+    }
+}
+impl Deref for ArcCommitMessages {
+    type Target = std::collections::HashMap<String, String>;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+#[derive(Clone)]
 pub struct ArcWptSummary(pub Arc<ScoreSummaryReport>);
 impl PartialEq for ArcWptSummary {
     fn eq(&self, other: &Self) -> bool {
@@ -237,7 +251,11 @@ fn month_ticks(x_min: f64, x_max: f64) -> Vec<(f64, String)> {
 }
 
 #[component]
-pub fn WptHistoryPage(summary: ArcWptSummary, range: ChartRange) -> Element {
+pub fn WptHistoryPage(
+    summary: ArcWptSummary,
+    range: ChartRange,
+    commit_messages: ArcCommitMessages,
+) -> Element {
     rsx! {
         Page { title: "Status: WPT History".into(),
             StatusHeader {}
@@ -249,7 +267,7 @@ pub fn WptHistoryPage(summary: ArcWptSummary, range: ChartRange) -> Element {
             }
             hr {}
             ChartRangeSelector { current_range: range }
-            WptHistoryChart { summary: summary.clone(), range }
+            WptHistoryChart { summary: summary.clone(), range, commit_messages }
             h2 { "Per-area history" }
             WptHistorySparklines { summary, range }
         }
@@ -290,8 +308,93 @@ const HIGHLIGHT_AREAS: &[(&str, &str)] = &[
     ("css/css-position", "#ba68c8"),
 ];
 
+/// Inline script implementing the hover tooltip as a progressive enhancement.
+/// Reads run data from the `#wpt-history-data` JSON blob and shows the nearest
+/// run's commit id, commit message, and per-area pass percentages.
+const TOOLTIP_JS: &str = r##"
+(function () {
+    var container = document.getElementById("wpt-history-chart");
+    var dataEl = document.getElementById("wpt-history-data");
+    if (!container || !dataEl) return;
+    var svg = container.querySelector("svg");
+    var data = JSON.parse(dataEl.textContent);
+    if (!svg || !data.runs.length) return;
+
+    var tip = document.createElement("div");
+    tip.style.cssText =
+        "position:absolute;pointer-events:none;display:none;background:rgba(255,255,255,0.96);" +
+        "border:1px solid #999;border-radius:4px;padding:6px 8px;font:12px sans-serif;" +
+        "box-shadow:0 1px 4px rgba(0,0,0,0.25);z-index:10;max-width:340px";
+    container.appendChild(tip);
+
+    var guide = document.createElementNS("http://www.w3.org/2000/svg", "line");
+    guide.setAttribute("stroke", "#888");
+    guide.setAttribute("stroke-dasharray", "3,3");
+    guide.setAttribute("y1", data.plot[1]);
+    guide.setAttribute("y2", data.plot[1] + data.plot[3]);
+    guide.style.display = "none";
+    svg.appendChild(guide);
+
+    function esc(s) {
+        return s.replace(/&/g, "&amp;").replace(/</g, "&lt;");
+    }
+
+    function nearest(x) {
+        var runs = data.runs, lo = 0, hi = runs.length - 1;
+        while (lo < hi) {
+            var mid = (lo + hi) >> 1;
+            if (runs[mid].x < x) lo = mid + 1; else hi = mid;
+        }
+        if (lo > 0 && Math.abs(runs[lo - 1].x - x) < Math.abs(runs[lo].x - x)) lo--;
+        return lo;
+    }
+
+    function hide() {
+        tip.style.display = "none";
+        guide.style.display = "none";
+    }
+
+    svg.addEventListener("mousemove", function (ev) {
+        var rect = svg.getBoundingClientRect();
+        var scale = data.width / rect.width;
+        var vx = (ev.clientX - rect.left) * scale;
+        var px = data.plot[0], pw = data.plot[2];
+        if (vx < px || vx > px + pw) { hide(); return; }
+
+        var xRange = data.xMax - data.xMin;
+        var run = data.runs[nearest(data.xMin + ((vx - px) / pw) * xRange)];
+        var runVx = px + ((run.x - data.xMin) / xRange) * pw;
+        guide.setAttribute("x1", runVx);
+        guide.setAttribute("x2", runVx);
+        guide.style.display = "";
+
+        var html = "<div style='font-weight:bold'>" + esc(run.sha.slice(0, 9)) + " (" + esc(run.d) + ")</div>";
+        if (run.msg) html += "<div style='margin-bottom:4px'>" + esc(run.msg) + "</div>";
+        for (var i = 0; i < data.series.length; i++) {
+            if (run.v[i] == null) continue;
+            html += "<div><span style='color:" + data.series[i].color + "'>\u25CF</span> " +
+                esc(data.series[i].name) + ": " + run.v[i].toFixed(1) + "%</div>";
+        }
+        tip.innerHTML = html;
+        tip.style.display = "block";
+
+        var crect = container.getBoundingClientRect();
+        var cx = ev.clientX - crect.left, cy = ev.clientY - crect.top;
+        var left = cx + 14;
+        if (left + tip.offsetWidth > container.clientWidth) left = cx - tip.offsetWidth - 14;
+        tip.style.left = left + "px";
+        tip.style.top = (cy + 14) + "px";
+    });
+    svg.addEventListener("mouseleave", hide);
+})();
+"##;
+
 #[component]
-pub fn WptHistoryChart(summary: ArcWptSummary, range: ChartRange) -> Element {
+pub fn WptHistoryChart(
+    summary: ArcWptSummary,
+    range: ChartRange,
+    commit_messages: ArcCommitMessages,
+) -> Element {
     const WIDTH: f64 = 900.0;
     const HEIGHT: f64 = 440.0;
     const PLOT: (f64, f64, f64, f64) = (50.0, 15.0, WIDTH - 65.0, HEIGHT - 55.0);
@@ -319,7 +422,59 @@ pub fn WptHistoryChart(summary: ArcWptSummary, range: ChartRange) -> Element {
     let ticks = month_ticks(x_min, x_max);
     let x_range = (x_max - x_min).max(f64::EPSILON);
 
+    // Per-run data for the hover tooltip (a JS progressive enhancement)
+    let area_indices: Vec<Option<usize>> = HIGHLIGHT_AREAS
+        .iter()
+        .map(|(area, _)| summary.focus_areas.iter().position(|a| a == area))
+        .collect();
+    let runs_json: Vec<serde_json::Value> = summary
+        .runs
+        .iter()
+        .filter_map(|run| {
+            let x = parse_date(&run.date)?;
+            if x < min_x {
+                return None;
+            }
+            let values: Vec<serde_json::Value> = area_indices
+                .iter()
+                .map(|idx| {
+                    idx.and_then(|idx| subtest_pass_percent(run, idx))
+                        .map(|pct| serde_json::json!((pct * 10.0).round() / 10.0))
+                        .unwrap_or(serde_json::Value::Null)
+                })
+                .collect();
+            Some(serde_json::json!({
+                "x": x,
+                "d": run.date.split('T').next().unwrap_or(&run.date),
+                "sha": run.product_revision,
+                "msg": commit_messages.get(&run.product_revision),
+                "v": values,
+            }))
+        })
+        .collect();
+    let tooltip_data = serde_json::json!({
+        "width": WIDTH,
+        "plot": [px, py, pw, ph],
+        "xMin": x_min,
+        "xMax": x_max,
+        "series": series
+            .iter()
+            .map(|s| serde_json::json!({
+                "name": s.name.strip_prefix("css/").unwrap_or("all css"),
+                "color": s.color,
+            }))
+            .collect::<Vec<_>>(),
+        "runs": runs_json,
+    })
+    .to_string()
+    // Prevent "</script>" in commit messages from terminating the data block
+    .replace('<', "\\u003c");
+
     rsx! {
+        div {
+            id: "wpt-history-chart",
+            position: "relative",
+
         svg {
             view_box: "0 0 {WIDTH} {HEIGHT}",
             width: "100%",
@@ -393,6 +548,14 @@ pub fn WptHistoryChart(summary: ArcWptSummary, range: ChartRange) -> Element {
                     {s.name.strip_prefix("css/").unwrap_or("all css")}
                 }
             }
+        }
+
+        script {
+            id: "wpt-history-data",
+            r#type: "application/json",
+            dangerous_inner_html: tooltip_data,
+        }
+        script { dangerous_inner_html: TOOLTIP_JS }
         }
     }
 }

--- a/src/routes/wpt_history.rs
+++ b/src/routes/wpt_history.rs
@@ -409,8 +409,8 @@ const TOOLTIP_JS: &str = r##"
             var dPct = 100 * (pass / total - prev.v[best][0] / prev.v[best][1]);
             var sign = dPass > 0 ? "+" : "";
             var color = dPass > 0 ? "#2e7d32" : (dPass < 0 ? "#c62828" : "#666");
-            html += "<div style='color:" + color + "'>\u0394 vs prev: " + sign +
-                dPass.toLocaleString() + " (" + sign + dPct.toFixed(2) + "pp)</div>";
+            html += "<div style='color:" + color + "'>Change: " + sign +
+                dPass.toLocaleString() + " (" + sign + dPct.toFixed(2) + "%)</div>";
         }
         tip.innerHTML = html;
         tip.style.display = "block";

--- a/src/routes/wpt_history.rs
+++ b/src/routes/wpt_history.rs
@@ -75,19 +75,6 @@ struct Series {
     points: Vec<(f64, f64)>,
 }
 
-/// Runs before this date are excluded from the charts: WPT runs for the
-/// entire prior commit history of Blitz were bulk-executed on 2026-04-13/14,
-/// so those runs' dates don't reflect real progress over time and include a
-/// number of broken runs.
-const CHART_START_DATE: &str = "2026-04-15";
-
-fn chart_runs(summary: &ScoreSummaryReport) -> impl Iterator<Item = &RunSummary> {
-    summary
-        .runs
-        .iter()
-        .filter(|run| run.date.as_str() >= CHART_START_DATE)
-}
-
 fn subtest_pass_percent(run: &RunSummary, area_idx: usize) -> Option<f64> {
     let scores = run.scores.get(area_idx)?;
     if scores.total_subtests == 0 {
@@ -102,7 +89,9 @@ fn area_series(
     color: &'static str,
 ) -> Option<Series> {
     let area_idx = summary.focus_areas.iter().position(|a| a == area)?;
-    let points: Vec<(f64, f64)> = chart_runs(summary)
+    let points: Vec<(f64, f64)> = summary
+        .runs
+        .iter()
         .filter_map(|run| Some((parse_date(&run.date)?, subtest_pass_percent(run, area_idx)?)))
         .collect();
     if points.is_empty() {
@@ -317,11 +306,13 @@ pub fn WptHistorySparklines(summary: ArcWptSummary) -> Element {
     const HEIGHT: f64 = 60.0;
     const PLOT: (f64, f64, f64, f64) = (0.0, 2.0, WIDTH, HEIGHT - 4.0);
 
-    let x_min = chart_runs(&summary)
-        .next()
+    let x_min = summary
+        .runs
+        .first()
         .and_then(|run| parse_date(&run.date))
         .unwrap_or(0.0);
-    let x_max = chart_runs(&summary)
+    let x_max = summary
+        .runs
         .last()
         .and_then(|run| parse_date(&run.date))
         .unwrap_or(1.0);
@@ -334,7 +325,9 @@ pub fn WptHistorySparklines(summary: ArcWptSummary) -> Element {
 
             for (area_idx, area) in summary.focus_areas.iter().enumerate() {
                 {
-                    let points: Vec<(f64, f64)> = chart_runs(&summary)
+                    let points: Vec<(f64, f64)> = summary
+                        .runs
+                        .iter()
                         .filter_map(|run| {
                             Some((parse_date(&run.date)?, subtest_pass_percent(run, area_idx)?))
                         })

--- a/src/routes/wpt_history.rs
+++ b/src/routes/wpt_history.rs
@@ -341,6 +341,13 @@ const TOOLTIP_JS: &str = r##"
     guide.style.display = "none";
     svg.appendChild(guide);
 
+    var dot = document.createElementNS("http://www.w3.org/2000/svg", "circle");
+    dot.setAttribute("r", 4);
+    dot.setAttribute("stroke", "white");
+    dot.setAttribute("stroke-width", 1.5);
+    dot.style.display = "none";
+    svg.appendChild(dot);
+
     function esc(s) {
         return s.replace(/&/g, "&amp;").replace(/</g, "&lt;");
     }
@@ -359,6 +366,7 @@ const TOOLTIP_JS: &str = r##"
     function hide() {
         tip.style.display = "none";
         guide.style.display = "none";
+        dot.style.display = "none";
     }
 
     // Only show the series whose line is within this vertical distance
@@ -392,6 +400,11 @@ const TOOLTIP_JS: &str = r##"
         guide.setAttribute("x1", runVx);
         guide.setAttribute("x2", runVx);
         guide.style.display = "";
+
+        dot.setAttribute("cx", runVx);
+        dot.setAttribute("cy", py + (1 - (run.v[best][0] / run.v[best][1])) * ph);
+        dot.setAttribute("fill", data.series[best].color);
+        dot.style.display = "";
 
         var html = "<div style='font-weight:bold'>" + esc(run.sha.slice(0, 9)) + " (" + esc(run.d) + ")</div>";
         if (run.msg) {

--- a/src/routes/wpt_history.rs
+++ b/src/routes/wpt_history.rs
@@ -69,6 +69,74 @@ const MONTH_NAMES: [&str; 12] = [
     "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
 ];
 
+#[derive(Copy, Clone, PartialEq, Debug, Default)]
+pub enum ChartRange {
+    Months3,
+    Months6,
+    Year1,
+    #[default]
+    All,
+}
+
+impl ChartRange {
+    pub const ALL: [ChartRange; 4] = [
+        ChartRange::Months3,
+        ChartRange::Months6,
+        ChartRange::Year1,
+        ChartRange::All,
+    ];
+
+    pub fn from_query(value: Option<&str>) -> Self {
+        match value {
+            Some("3m") => ChartRange::Months3,
+            Some("6m") => ChartRange::Months6,
+            Some("1y") => ChartRange::Year1,
+            _ => ChartRange::All,
+        }
+    }
+
+    fn query_value(self) -> &'static str {
+        match self {
+            ChartRange::Months3 => "3m",
+            ChartRange::Months6 => "6m",
+            ChartRange::Year1 => "1y",
+            ChartRange::All => "all",
+        }
+    }
+
+    fn label(self) -> &'static str {
+        match self {
+            ChartRange::Months3 => "3 months",
+            ChartRange::Months6 => "6 months",
+            ChartRange::Year1 => "1 year",
+            ChartRange::All => "All time",
+        }
+    }
+
+    fn days(self) -> Option<f64> {
+        match self {
+            ChartRange::Months3 => Some(91.0),
+            ChartRange::Months6 => Some(183.0),
+            ChartRange::Year1 => Some(365.0),
+            ChartRange::All => None,
+        }
+    }
+
+    /// The earliest date (in fractional epoch-days) included in the range,
+    /// measured back from the date of the latest run
+    fn min_x(self, summary: &ScoreSummaryReport) -> f64 {
+        let latest = summary
+            .runs
+            .last()
+            .and_then(|run| parse_date(&run.date))
+            .unwrap_or(0.0);
+        match self.days() {
+            Some(days) => latest - days,
+            None => f64::NEG_INFINITY,
+        }
+    }
+}
+
 struct Series {
     name: &'static str,
     color: &'static str,
@@ -85,6 +153,7 @@ fn subtest_pass_percent(run: &RunSummary, area_idx: usize) -> Option<f64> {
 
 fn area_series(
     summary: &ScoreSummaryReport,
+    min_x: f64,
     area: &'static str,
     color: &'static str,
 ) -> Option<Series> {
@@ -93,6 +162,7 @@ fn area_series(
         .runs
         .iter()
         .filter_map(|run| Some((parse_date(&run.date)?, subtest_pass_percent(run, area_idx)?)))
+        .filter(|(x, _)| *x >= min_x)
         .collect();
     if points.is_empty() {
         return None;
@@ -167,7 +237,7 @@ fn month_ticks(x_min: f64, x_max: f64) -> Vec<(f64, String)> {
 }
 
 #[component]
-pub fn WptHistoryPage(summary: ArcWptSummary) -> Element {
+pub fn WptHistoryPage(summary: ArcWptSummary, range: ChartRange) -> Element {
     rsx! {
         Page { title: "Status: WPT History".into(),
             StatusHeader {}
@@ -178,9 +248,35 @@ pub fn WptHistoryPage(summary: ArcWptSummary) -> Element {
                 Scores are the percentage of subtests passing (of those that Blitz can run). Data is recorded for every commit to the main branch."#
             }
             hr {}
-            WptHistoryChart { summary: summary.clone() }
+            ChartRangeSelector { current_range: range }
+            WptHistoryChart { summary: summary.clone(), range }
             h2 { "Per-area history" }
-            WptHistorySparklines { summary }
+            WptHistorySparklines { summary, range }
+        }
+    }
+}
+
+#[component]
+pub fn ChartRangeSelector(current_range: ChartRange) -> Element {
+    rsx! {
+        div {
+            display: "flex",
+            gap: "8px",
+            justify_content: "flex-end",
+            font_size: "14px",
+            margin_bottom: "8px",
+
+            for range in ChartRange::ALL {
+                a {
+                    href: "/status/wpt/history?range={range.query_value()}",
+                    padding: "2px 10px",
+                    border_radius: "12px",
+                    text_decoration: "none",
+                    color: if range == current_range { "white" } else { "inherit" },
+                    background_color: if range == current_range { "#2b6e6c" } else { "#eee" },
+                    {range.label()}
+                }
+            }
         }
     }
 }
@@ -195,15 +291,16 @@ const HIGHLIGHT_AREAS: &[(&str, &str)] = &[
 ];
 
 #[component]
-pub fn WptHistoryChart(summary: ArcWptSummary) -> Element {
+pub fn WptHistoryChart(summary: ArcWptSummary, range: ChartRange) -> Element {
     const WIDTH: f64 = 900.0;
     const HEIGHT: f64 = 440.0;
     const PLOT: (f64, f64, f64, f64) = (50.0, 15.0, WIDTH - 65.0, HEIGHT - 55.0);
     let (px, py, pw, ph) = PLOT;
 
+    let min_x = range.min_x(&summary);
     let series: Vec<Series> = HIGHLIGHT_AREAS
         .iter()
-        .filter_map(|(area, color)| area_series(&summary, area, color))
+        .filter_map(|(area, color)| area_series(&summary, min_x, area, color))
         .collect();
 
     let x_min = series
@@ -301,16 +398,18 @@ pub fn WptHistoryChart(summary: ArcWptSummary) -> Element {
 }
 
 #[component]
-pub fn WptHistorySparklines(summary: ArcWptSummary) -> Element {
+pub fn WptHistorySparklines(summary: ArcWptSummary, range: ChartRange) -> Element {
     const WIDTH: f64 = 260.0;
     const HEIGHT: f64 = 60.0;
     const PLOT: (f64, f64, f64, f64) = (0.0, 2.0, WIDTH, HEIGHT - 4.0);
 
+    let range_min_x = range.min_x(&summary);
     let x_min = summary
         .runs
         .first()
         .and_then(|run| parse_date(&run.date))
-        .unwrap_or(0.0);
+        .unwrap_or(0.0)
+        .max(range_min_x);
     let x_max = summary
         .runs
         .last()
@@ -331,6 +430,7 @@ pub fn WptHistorySparklines(summary: ArcWptSummary) -> Element {
                         .filter_map(|run| {
                             Some((parse_date(&run.date)?, subtest_pass_percent(run, area_idx)?))
                         })
+                        .filter(|(x, _)| *x >= range_min_x)
                         .collect();
 
                     let latest = points.last().map(|p| p.1).unwrap_or(0.0);

--- a/src/routes/wpt_history.rs
+++ b/src/routes/wpt_history.rs
@@ -375,8 +375,10 @@ const TOOLTIP_JS: &str = r##"
         }
         for (var i = 0; i < data.series.length; i++) {
             if (run.v[i] == null) continue;
+            var pass = run.v[i][0], total = run.v[i][1];
             html += "<div><span style='color:" + data.series[i].color + "'>\u25CF</span> " +
-                esc(data.series[i].name) + ": " + run.v[i].toFixed(1) + "%</div>";
+                esc(data.series[i].name) + ": " + (100 * pass / total).toFixed(1) + "% (" +
+                pass.toLocaleString() + "/" + total.toLocaleString() + ")</div>";
         }
         tip.innerHTML = html;
         tip.style.display = "block";
@@ -441,8 +443,14 @@ pub fn WptHistoryChart(
             let values: Vec<serde_json::Value> = area_indices
                 .iter()
                 .map(|idx| {
-                    idx.and_then(|idx| subtest_pass_percent(run, idx))
-                        .map(|pct| serde_json::json!((pct * 10.0).round() / 10.0))
+                    idx.and_then(|idx| run.scores.get(idx))
+                        .filter(|scores| scores.total_subtests != 0)
+                        .map(|scores| {
+                            serde_json::json!([
+                                scores.total_subtests_passed,
+                                scores.total_subtests
+                            ])
+                        })
                         .unwrap_or(serde_json::Value::Null)
                 })
                 .collect();

--- a/src/routes/wpt_history.rs
+++ b/src/routes/wpt_history.rs
@@ -1,0 +1,364 @@
+use std::{fmt::Write, ops::Deref, sync::Arc};
+
+use dioxus::prelude::*;
+use wptreport::score_summary::{RunSummary, ScoreSummaryReport};
+
+use crate::routes::{StatusHeader, StatusTabs};
+use crate::components::Page;
+
+#[derive(Clone)]
+pub struct ArcWptSummary(pub Arc<ScoreSummaryReport>);
+impl PartialEq for ArcWptSummary {
+    fn eq(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.0, &other.0)
+    }
+}
+impl Deref for ArcWptSummary {
+    type Target = ScoreSummaryReport;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+/// Days since 1970-01-01 for a year/month/day (Howard Hinnant's civil-days algorithm)
+fn days_from_civil(y: i64, m: i64, d: i64) -> i64 {
+    let y = if m <= 2 { y - 1 } else { y };
+    let era = if y >= 0 { y } else { y - 399 } / 400;
+    let yoe = y - era * 400;
+    let mp = (m + 9) % 12;
+    let doy = (153 * mp + 2) / 5 + d - 1;
+    let doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;
+    era * 146097 + doe - 719468
+}
+
+/// Parse a date of the form YYYY-MM-DD or YYYY-MM-DDTHH:MM:SSZ into fractional
+/// days since the unix epoch.
+fn parse_date(date: &str) -> Option<f64> {
+    let year: i64 = date.get(0..4)?.parse().ok()?;
+    let month: i64 = date.get(5..7)?.parse().ok()?;
+    let day: i64 = date.get(8..10)?.parse().ok()?;
+    let mut days = days_from_civil(year, month, day) as f64;
+
+    if let (Some(h), Some(m), Some(s)) = (date.get(11..13), date.get(14..16), date.get(17..19)) {
+        let (h, m, s): (f64, f64, f64) = (
+            h.parse().unwrap_or(0.0),
+            m.parse().unwrap_or(0.0),
+            s.parse().unwrap_or(0.0),
+        );
+        days += (h * 3600.0 + m * 60.0 + s) / 86400.0;
+    }
+
+    Some(days)
+}
+
+/// Convert fractional days since the unix epoch back into a (year, month) pair
+fn civil_from_days(z: i64) -> (i64, i64) {
+    let z = z + 719468;
+    let era = if z >= 0 { z } else { z - 146096 } / 146097;
+    let doe = z - era * 146097;
+    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146096) / 365;
+    let y = yoe + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let m = if mp < 10 { mp + 3 } else { mp - 9 };
+    let y = if m <= 2 { y + 1 } else { y };
+    (y, m)
+}
+
+const MONTH_NAMES: [&str; 12] = [
+    "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
+];
+
+struct Series {
+    name: &'static str,
+    color: &'static str,
+    points: Vec<(f64, f64)>,
+}
+
+fn subtest_pass_percent(run: &RunSummary, area_idx: usize) -> Option<f64> {
+    let scores = run.scores.get(area_idx)?;
+    if scores.total_subtests == 0 {
+        return None;
+    }
+    Some(scores.total_subtests_passed as f64 / scores.total_subtests as f64 * 100.0)
+}
+
+fn area_series(
+    summary: &ScoreSummaryReport,
+    area: &'static str,
+    color: &'static str,
+) -> Option<Series> {
+    let area_idx = summary.focus_areas.iter().position(|a| a == area)?;
+    let points: Vec<(f64, f64)> = summary
+        .runs
+        .iter()
+        .filter_map(|run| Some((parse_date(&run.date)?, subtest_pass_percent(run, area_idx)?)))
+        .collect();
+    if points.is_empty() {
+        return None;
+    }
+    Some(Series {
+        name: area,
+        color,
+        points,
+    })
+}
+
+fn polyline_points(
+    points: &[(f64, f64)],
+    x_min: f64,
+    x_max: f64,
+    plot: (f64, f64, f64, f64), // (x, y, width, height) of plot area
+) -> String {
+    if points.is_empty() {
+        return String::new();
+    }
+
+    let (px, py, pw, ph) = plot;
+    let x_range = (x_max - x_min).max(f64::EPSILON);
+
+    // Downsample long series to at most ~400 points to keep the SVG small
+    let stride = points.len().div_ceil(400).max(1);
+    let mut out = String::new();
+    let mut plot_point = |&(x, y): &(f64, f64)| {
+        let sx = px + (x - x_min) / x_range * pw;
+        let sy = py + (1.0 - y / 100.0) * ph;
+        write!(out, "{sx:.1},{sy:.1} ").unwrap();
+    };
+    for point in points.iter().step_by(stride) {
+        plot_point(point);
+    }
+    // Always include the final point so the latest result is shown
+    let last_plotted = (points.len() - 1) / stride * stride;
+    if last_plotted != points.len() - 1 {
+        plot_point(&points[points.len() - 1]);
+    }
+    out
+}
+
+/// Month boundaries (as fractional epoch-days) within the given range, for x-axis ticks
+fn month_ticks(x_min: f64, x_max: f64) -> Vec<(f64, String)> {
+    let (mut year, mut month) = civil_from_days(x_min.floor() as i64);
+    // Advance to the first month boundary >= x_min
+    month += 1;
+    if month > 12 {
+        month = 1;
+        year += 1;
+    }
+
+    let mut ticks = Vec::new();
+    loop {
+        let days = days_from_civil(year, month, 1) as f64;
+        if days > x_max {
+            break;
+        }
+        let label = format!("{} {}", MONTH_NAMES[(month - 1) as usize], year);
+        ticks.push((days, label));
+        month += 1;
+        if month > 12 {
+            month = 1;
+            year += 1;
+        }
+    }
+
+    // Thin out ticks if there are too many to label legibly
+    let stride = ticks.len().div_ceil(12).max(1);
+    ticks.into_iter().step_by(stride).collect()
+}
+
+#[component]
+pub fn WptHistoryPage(summary: ArcWptSummary) -> Element {
+    rsx! {
+        Page { title: "Status: WPT History".into(),
+            StatusHeader {}
+            StatusTabs { current_tab: "history" }
+            p {
+                dangerous_inner_html: r#"
+                This page charts Blitz's scores on the "css" subsuite of the <a href="https://github.com/web-platform-tests/wpt" target="_blank">Web Platform Tests</a> over time.
+                Scores are the percentage of subtests passing (of those that Blitz can run). Data is recorded for every commit to the main branch."#
+            }
+            hr {}
+            WptHistoryChart { summary: summary.clone() }
+            h2 { "Per-area history" }
+            WptHistorySparklines { summary }
+        }
+    }
+}
+
+const HIGHLIGHT_AREAS: &[(&str, &str)] = &[
+    ("css", "#000000"),
+    ("css/CSS2", "#e57373"),
+    ("css/css-flexbox", "#7986cb"),
+    ("css/css-grid", "#4db6ac"),
+    ("css/css-text", "#ffb74d"),
+    ("css/css-position", "#ba68c8"),
+];
+
+#[component]
+pub fn WptHistoryChart(summary: ArcWptSummary) -> Element {
+    const WIDTH: f64 = 900.0;
+    const HEIGHT: f64 = 440.0;
+    const PLOT: (f64, f64, f64, f64) = (50.0, 15.0, WIDTH - 65.0, HEIGHT - 55.0);
+    let (px, py, pw, ph) = PLOT;
+
+    let series: Vec<Series> = HIGHLIGHT_AREAS
+        .iter()
+        .filter_map(|(area, color)| area_series(&summary, area, color))
+        .collect();
+
+    let x_min = series
+        .iter()
+        .filter_map(|s| s.points.first().map(|p| p.0))
+        .fold(f64::INFINITY, f64::min);
+    let x_max = series
+        .iter()
+        .filter_map(|s| s.points.last().map(|p| p.0))
+        .fold(f64::NEG_INFINITY, f64::max);
+
+    if !x_min.is_finite() || !x_max.is_finite() {
+        return rsx!( p { "No history data available" } );
+    }
+
+    let ticks = month_ticks(x_min, x_max);
+    let x_range = (x_max - x_min).max(f64::EPSILON);
+
+    rsx! {
+        svg {
+            view_box: "0 0 {WIDTH} {HEIGHT}",
+            width: "100%",
+            font_family: "sans-serif",
+
+            // Horizontal gridlines + y-axis labels (every 10%)
+            for i in 0..=10u32 {
+                line {
+                    x1: "{px}",
+                    x2: "{px + pw}",
+                    y1: "{py + ph * (1.0 - (i as f64) / 10.0)}",
+                    y2: "{py + ph * (1.0 - (i as f64) / 10.0)}",
+                    stroke: if i % 5 == 0 { "#bbb" } else { "#e5e5e5" },
+                    stroke_width: "1",
+                }
+                text {
+                    x: "{px - 6.0}",
+                    y: "{py + ph * (1.0 - (i as f64) / 10.0) + 4.0}",
+                    text_anchor: "end",
+                    font_size: "12",
+                    fill: "#666",
+                    "{i * 10}%"
+                }
+            }
+
+            // X-axis ticks and labels (month boundaries)
+            for (days, label) in ticks {
+                line {
+                    x1: "{px + (days - x_min) / x_range * pw}",
+                    x2: "{px + (days - x_min) / x_range * pw}",
+                    y1: "{py}",
+                    y2: "{py + ph + 4.0}",
+                    stroke: "#e5e5e5",
+                    stroke_width: "1",
+                }
+                text {
+                    x: "{px + (days - x_min) / x_range * pw}",
+                    y: "{py + ph + 18.0}",
+                    text_anchor: "middle",
+                    font_size: "12",
+                    fill: "#666",
+                    {label}
+                }
+            }
+
+            // Data series
+            for s in series.iter() {
+                polyline {
+                    points: polyline_points(&s.points, x_min, x_max, PLOT),
+                    fill: "none",
+                    stroke: s.color,
+                    stroke_width: if s.name == "css" { "2.5" } else { "1.5" },
+                }
+            }
+
+            // Legend
+            for (i, s) in series.iter().enumerate() {
+                line {
+                    x1: "{px + 10.0 + (i as f64) * 140.0}",
+                    x2: "{px + 34.0 + (i as f64) * 140.0}",
+                    y1: "{HEIGHT - 10.0}",
+                    y2: "{HEIGHT - 10.0}",
+                    stroke: s.color,
+                    stroke_width: "3",
+                }
+                text {
+                    x: "{px + 40.0 + (i as f64) * 140.0}",
+                    y: "{HEIGHT - 6.0}",
+                    font_size: "12",
+                    fill: "#333",
+                    {s.name.strip_prefix("css/").unwrap_or("all css")}
+                }
+            }
+        }
+    }
+}
+
+#[component]
+pub fn WptHistorySparklines(summary: ArcWptSummary) -> Element {
+    const WIDTH: f64 = 260.0;
+    const HEIGHT: f64 = 60.0;
+    const PLOT: (f64, f64, f64, f64) = (0.0, 2.0, WIDTH, HEIGHT - 4.0);
+
+    let x_min = summary
+        .runs
+        .first()
+        .and_then(|run| parse_date(&run.date))
+        .unwrap_or(0.0);
+    let x_max = summary
+        .runs
+        .last()
+        .and_then(|run| parse_date(&run.date))
+        .unwrap_or(1.0);
+
+    rsx! {
+        div {
+            display: "grid",
+            grid_template_columns: "repeat(auto-fill, minmax(280px, 1fr))",
+            gap: "16px",
+
+            for (area_idx, area) in summary.focus_areas.iter().enumerate() {
+                {
+                    let points: Vec<(f64, f64)> = summary
+                        .runs
+                        .iter()
+                        .filter_map(|run| {
+                            Some((parse_date(&run.date)?, subtest_pass_percent(run, area_idx)?))
+                        })
+                        .collect();
+
+                    let latest = points.last().map(|p| p.1).unwrap_or(0.0);
+
+                    rsx! {
+                        div {
+                            div {
+                                display: "flex",
+                                justify_content: "space-between",
+                                font_size: "13px",
+                                span { {area.clone()} }
+                                span { {format!("{latest:.1}%")} }
+                            }
+                            svg {
+                                view_box: "0 0 {WIDTH} {HEIGHT}",
+                                width: "100%",
+                                style: "border: 1px solid #ddd",
+                                polyline {
+                                    points: polyline_points(&points, x_min, x_max, PLOT),
+                                    fill: "none",
+                                    stroke: "#7986cb",
+                                    stroke_width: "1.5",
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/routes/wpt_history.rs
+++ b/src/routes/wpt_history.rs
@@ -354,15 +354,31 @@ const TOOLTIP_JS: &str = r##"
         guide.style.display = "none";
     }
 
+    // Only show the series whose line is within this vertical distance
+    // (in viewBox units) of the cursor
+    var Y_THRESHOLD = 12;
+
     svg.addEventListener("mousemove", function (ev) {
         var rect = svg.getBoundingClientRect();
         var scale = data.width / rect.width;
         var vx = (ev.clientX - rect.left) * scale;
-        var px = data.plot[0], pw = data.plot[2];
+        var vy = (ev.clientY - rect.top) * scale;
+        var px = data.plot[0], py = data.plot[1], pw = data.plot[2], ph = data.plot[3];
         if (vx < px || vx > px + pw) { hide(); return; }
 
         var xRange = data.xMax - data.xMin;
         var run = data.runs[nearest(data.xMin + ((vx - px) / pw) * xRange)];
+
+        // Pick the single series whose line is vertically nearest the cursor
+        var best = -1, bestDist = Y_THRESHOLD;
+        for (var i = 0; i < data.series.length; i++) {
+            if (run.v[i] == null) continue;
+            var sy = py + (1 - (run.v[i][0] / run.v[i][1])) * ph;
+            var dist = Math.abs(sy - vy);
+            if (dist < bestDist) { best = i; bestDist = dist; }
+        }
+        if (best < 0) { hide(); return; }
+
         var runVx = px + ((run.x - data.xMin) / xRange) * pw;
         guide.setAttribute("x1", runVx);
         guide.setAttribute("x2", runVx);
@@ -373,13 +389,10 @@ const TOOLTIP_JS: &str = r##"
             html += "<div style='margin-bottom:4px;white-space:nowrap;overflow:hidden;" +
                 "text-overflow:ellipsis'>" + esc(run.msg) + "</div>";
         }
-        for (var i = 0; i < data.series.length; i++) {
-            if (run.v[i] == null) continue;
-            var pass = run.v[i][0], total = run.v[i][1];
-            html += "<div><span style='color:" + data.series[i].color + "'>\u25CF</span> " +
-                esc(data.series[i].name) + ": " + (100 * pass / total).toFixed(1) + "% (" +
-                pass.toLocaleString() + "/" + total.toLocaleString() + ")</div>";
-        }
+        var pass = run.v[best][0], total = run.v[best][1];
+        html += "<div><span style='color:" + data.series[best].color + "'>\u25CF</span> " +
+            esc(data.series[best].name) + ": " + (100 * pass / total).toFixed(1) + "% (" +
+            pass.toLocaleString() + "/" + total.toLocaleString() + ")</div>";
         tip.innerHTML = html;
         tip.style.display = "block";
 

--- a/src/routes/wpt_history.rs
+++ b/src/routes/wpt_history.rs
@@ -75,6 +75,19 @@ struct Series {
     points: Vec<(f64, f64)>,
 }
 
+/// Runs before this date are excluded from the charts: WPT runs for the
+/// entire prior commit history of Blitz were bulk-executed on 2026-04-13/14,
+/// so those runs' dates don't reflect real progress over time and include a
+/// number of broken runs.
+const CHART_START_DATE: &str = "2026-04-15";
+
+fn chart_runs(summary: &ScoreSummaryReport) -> impl Iterator<Item = &RunSummary> {
+    summary
+        .runs
+        .iter()
+        .filter(|run| run.date.as_str() >= CHART_START_DATE)
+}
+
 fn subtest_pass_percent(run: &RunSummary, area_idx: usize) -> Option<f64> {
     let scores = run.scores.get(area_idx)?;
     if scores.total_subtests == 0 {
@@ -89,9 +102,7 @@ fn area_series(
     color: &'static str,
 ) -> Option<Series> {
     let area_idx = summary.focus_areas.iter().position(|a| a == area)?;
-    let points: Vec<(f64, f64)> = summary
-        .runs
-        .iter()
+    let points: Vec<(f64, f64)> = chart_runs(summary)
         .filter_map(|run| Some((parse_date(&run.date)?, subtest_pass_percent(run, area_idx)?)))
         .collect();
     if points.is_empty() {
@@ -306,13 +317,11 @@ pub fn WptHistorySparklines(summary: ArcWptSummary) -> Element {
     const HEIGHT: f64 = 60.0;
     const PLOT: (f64, f64, f64, f64) = (0.0, 2.0, WIDTH, HEIGHT - 4.0);
 
-    let x_min = summary
-        .runs
-        .first()
+    let x_min = chart_runs(&summary)
+        .next()
         .and_then(|run| parse_date(&run.date))
         .unwrap_or(0.0);
-    let x_max = summary
-        .runs
+    let x_max = chart_runs(&summary)
         .last()
         .and_then(|run| parse_date(&run.date))
         .unwrap_or(1.0);
@@ -325,9 +334,7 @@ pub fn WptHistorySparklines(summary: ArcWptSummary) -> Element {
 
             for (area_idx, area) in summary.focus_areas.iter().enumerate() {
                 {
-                    let points: Vec<(f64, f64)> = summary
-                        .runs
-                        .iter()
+                    let points: Vec<(f64, f64)> = chart_runs(&summary)
                         .filter_map(|run| {
                             Some((parse_date(&run.date)?, subtest_pass_percent(run, area_idx)?))
                         })

--- a/src/wpt_history.rs
+++ b/src/wpt_history.rs
@@ -1,0 +1,85 @@
+use std::{
+    sync::{Arc, Mutex},
+    time::Instant,
+};
+
+use reqwest::Client;
+use wptreport::score_summary::ScoreSummaryReport;
+
+use crate::routes::ArcWptSummary;
+
+const SUMMARY_URL: &str =
+    "https://raw.githubusercontent.com/DioxusLabs/blitz-wpt-results/main/summary.json";
+
+pub static WPT_HISTORY_CACHE: WptHistoryCache = WptHistoryCache::new();
+
+pub struct WptHistoryCache(Mutex<Option<Arc<WptHistoryCacheEntry>>>);
+impl WptHistoryCache {
+    const fn new() -> Self {
+        Self(Mutex::new(None))
+    }
+
+    pub fn get_cloned(&self) -> Option<Arc<WptHistoryCacheEntry>> {
+        (*self.0.lock().unwrap()).clone()
+    }
+
+    pub fn update(&self, etag: Option<Arc<str>>, summary: ArcWptSummary) {
+        let cached_at = Instant::now();
+        *self.0.lock().unwrap() = Some(Arc::new(WptHistoryCacheEntry {
+            etag,
+            cached_at,
+            summary,
+        }));
+    }
+
+    pub fn mark_as_fresh(&self) {
+        let cached_at = Instant::now();
+        let mut inner = self.0.lock().unwrap();
+        if let Some(entry) = inner.take() {
+            *inner = Some(Arc::new(WptHistoryCacheEntry {
+                cached_at,
+                etag: entry.etag.clone(),
+                summary: entry.summary.clone(),
+            }));
+        }
+    }
+}
+
+pub struct WptHistoryCacheEntry {
+    pub etag: Option<Arc<str>>,
+    pub cached_at: Instant,
+    pub summary: ArcWptSummary,
+}
+
+pub async fn load_wpt_history(etag: Option<Arc<str>>) {
+    println!("Checking for new WPT history summary...");
+
+    let client = Client::new();
+    let mut builder = client.get(SUMMARY_URL);
+
+    if let Some(etag) = etag.as_ref() {
+        builder = builder.header("If-None-Match", &**etag);
+    }
+    let result = builder.send().await.unwrap();
+
+    if result.status() == 304 {
+        println!("WPT history summary unchanged");
+        WPT_HISTORY_CACHE.mark_as_fresh();
+        return;
+    }
+
+    let etag = result
+        .headers()
+        .get("etag")
+        .and_then(|header| header.to_str().ok())
+        .map(Arc::from);
+
+    println!("New WPT history summary found. etag: {etag:?}");
+
+    let body = result.bytes().await.unwrap();
+    let summary: ScoreSummaryReport = serde_json::from_slice(&body).unwrap();
+
+    WPT_HISTORY_CACHE.update(etag, ArcWptSummary(Arc::new(summary)));
+
+    println!("New WPT history summary processed and cached.");
+}

--- a/src/wpt_history.rs
+++ b/src/wpt_history.rs
@@ -5,7 +5,8 @@ use std::{
 };
 
 use reqwest::Client;
-use wptreport::score_summary::ScoreSummaryReport;
+use serde::Deserialize;
+use wptreport::score_summary::{RunScores, RunSummary, ScoreSummaryReport};
 
 use crate::routes::{ArcCommitMessages, ArcWptSummary};
 
@@ -13,6 +14,54 @@ const SUMMARY_URL: &str =
     "https://raw.githubusercontent.com/DioxusLabs/blitz-wpt-results/main/summary.json";
 const COMMIT_MESSAGES_URL: &str =
     "https://raw.githubusercontent.com/DioxusLabs/blitz-wpt-results/main/commit-messages.json";
+
+/// The compact on-disk format of summary.json: per-area scores are stored as
+/// `[total_tests, total_score, total_subtests, total_subtests_passed]` arrays
+/// (parallel to `focus_areas`)
+#[derive(Deserialize)]
+struct CompactSummary {
+    focus_areas: Vec<String>,
+    runs: Vec<CompactRun>,
+}
+
+#[derive(Deserialize)]
+struct CompactRun {
+    date: String,
+    wpt_revision: String,
+    product_revision: String,
+    scores: Vec<(u32, f64, u32, u32)>,
+}
+
+impl From<CompactSummary> for ScoreSummaryReport {
+    fn from(compact: CompactSummary) -> Self {
+        ScoreSummaryReport {
+            focus_areas: compact.focus_areas,
+            runs: compact
+                .runs
+                .into_iter()
+                .map(|run| RunSummary {
+                    date: run.date,
+                    wpt_revision: run.wpt_revision,
+                    product_revision: run.product_revision,
+                    scores: run
+                        .scores
+                        .into_iter()
+                        .map(
+                            |(total_tests, total_score, total_subtests, total_subtests_passed)| {
+                                RunScores {
+                                    total_tests,
+                                    total_score,
+                                    total_subtests,
+                                    total_subtests_passed,
+                                }
+                            },
+                        )
+                        .collect(),
+                })
+                .collect(),
+        }
+    }
+}
 
 pub static WPT_HISTORY_CACHE: WptHistoryCache = WptHistoryCache::new();
 
@@ -88,7 +137,8 @@ pub async fn load_wpt_history(etag: Option<Arc<str>>) {
     println!("New WPT history summary found. etag: {etag:?}");
 
     let body = result.bytes().await.unwrap();
-    let summary: ScoreSummaryReport = serde_json::from_slice(&body).unwrap();
+    let compact: CompactSummary = serde_json::from_slice(&body).unwrap();
+    let summary = ScoreSummaryReport::from(compact);
 
     // Commit messages are optional: tooltips degrade gracefully without them
     let commit_messages: HashMap<String, String> = match client

--- a/src/wpt_history.rs
+++ b/src/wpt_history.rs
@@ -1,4 +1,5 @@
 use std::{
+    collections::HashMap,
     sync::{Arc, Mutex},
     time::Instant,
 };
@@ -6,10 +7,12 @@ use std::{
 use reqwest::Client;
 use wptreport::score_summary::ScoreSummaryReport;
 
-use crate::routes::ArcWptSummary;
+use crate::routes::{ArcCommitMessages, ArcWptSummary};
 
 const SUMMARY_URL: &str =
     "https://raw.githubusercontent.com/DioxusLabs/blitz-wpt-results/main/summary.json";
+const COMMIT_MESSAGES_URL: &str =
+    "https://raw.githubusercontent.com/DioxusLabs/blitz-wpt-results/main/commit-messages.json";
 
 pub static WPT_HISTORY_CACHE: WptHistoryCache = WptHistoryCache::new();
 
@@ -23,12 +26,18 @@ impl WptHistoryCache {
         (*self.0.lock().unwrap()).clone()
     }
 
-    pub fn update(&self, etag: Option<Arc<str>>, summary: ArcWptSummary) {
+    pub fn update(
+        &self,
+        etag: Option<Arc<str>>,
+        summary: ArcWptSummary,
+        commit_messages: ArcCommitMessages,
+    ) {
         let cached_at = Instant::now();
         *self.0.lock().unwrap() = Some(Arc::new(WptHistoryCacheEntry {
             etag,
             cached_at,
             summary,
+            commit_messages,
         }));
     }
 
@@ -40,6 +49,7 @@ impl WptHistoryCache {
                 cached_at,
                 etag: entry.etag.clone(),
                 summary: entry.summary.clone(),
+                commit_messages: entry.commit_messages.clone(),
             }));
         }
     }
@@ -49,6 +59,7 @@ pub struct WptHistoryCacheEntry {
     pub etag: Option<Arc<str>>,
     pub cached_at: Instant,
     pub summary: ArcWptSummary,
+    pub commit_messages: ArcCommitMessages,
 }
 
 pub async fn load_wpt_history(etag: Option<Arc<str>>) {
@@ -79,7 +90,25 @@ pub async fn load_wpt_history(etag: Option<Arc<str>>) {
     let body = result.bytes().await.unwrap();
     let summary: ScoreSummaryReport = serde_json::from_slice(&body).unwrap();
 
-    WPT_HISTORY_CACHE.update(etag, ArcWptSummary(Arc::new(summary)));
+    // Commit messages are optional: tooltips degrade gracefully without them
+    let commit_messages: HashMap<String, String> = match client
+        .get(COMMIT_MESSAGES_URL)
+        .send()
+        .await
+        .and_then(|res| res.error_for_status())
+    {
+        Ok(res) => serde_json::from_slice(&res.bytes().await.unwrap()).unwrap_or_default(),
+        Err(err) => {
+            println!("Failed to fetch commit messages: {err}");
+            HashMap::new()
+        }
+    };
+
+    WPT_HISTORY_CACHE.update(
+        etag,
+        ArcWptSummary(Arc::new(summary)),
+        ArcCommitMessages(Arc::new(commit_messages)),
+    );
 
     println!("New WPT history summary processed and cached.");
 }


### PR DESCRIPTION
## Summary

Adds a `/status/wpt/history` page (new "WPT History" tab) charting Blitz's WPT scores over time, using the `summary.json` time series produced by DioxusLabs/blitz-wpt-results#1.

- `src/wpt_history.rs`: fetches `summary.json` (and the `commit-messages.json` sidecar) from `raw.githubusercontent.com/DioxusLabs/blitz-wpt-results/main` into `WPT_HISTORY_CACHE`, with the same etag + 30s/30min revalidation pattern as `WPT_REPORT_CACHE`; route handler in `main.rs` mirrors `/status/wpt`.
- `src/routes/wpt_history.rs`: server-rendered SVG charts, no JS dependency:
  - `WptHistoryChart`: main line chart of subtest-pass % over time for highlighted areas (`css` overall, CSS2, flexbox, grid, text, position) with month-boundary x-ticks and 10% y-gridlines.
  - `ChartRangeSelector`: 3 months / 6 months / 1 year / All time pill links driven by a `?range=3m|6m|1y|all` query param (`ChartRange`), filtering both the chart and the sparklines. No JS required.
  - Hover tooltip as a progressive enhancement: per-run data (date, sha, commit message, per-series %) is embedded as a `<script type="application/json">` blob and a small inline vanilla script (`TOOLTIP_JS`) shows the nearest run's commit id, commit message, and pass %s with a vertical guide line. Without JS the chart renders identically, just without tooltips.
  - `WptHistorySparklines`: fixed 0-100% sparkline per focus area (all 117), with latest %.
  - Dates are parsed and month ticks computed with dependency-free civil-days conversions (`days_from_civil`/`civil_from_days`); long series are downsampled to ≤400 points per polyline (always keeping the final point) to keep the page ~370KB.

Screenshots (rendered locally against the branch summary data):

![main chart with tooltip](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctYzA4ZWNhZTVlODUwNGJlY2I0MWE1NmY1ZGYwYjE2N2UiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctYzA4ZWNhZTVlODUwNGJlY2I0MWE1NmY1ZGYwYjE2N2UvMWFmNTVhMmYtYTQ0OS00ZTllLWIwNGQtNTlmZGE2NjExM2VhIiwiaWF0IjoxNzg2MzE2NzA2LCJleHAiOjE3ODY5MjE1MDYsImZpbGVuYW1lIjoic3NfNGFhMjZmOWQucG5nIn0.Ktw1mmnVkb28WjuOJo_VKTuGLBXtvu0JGbcqr264FGY)
![sparklines](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmctYzA4ZWNhZTVlODUwNGJlY2I0MWE1NmY1ZGYwYjE2N2UiLCJ1c2VyX2lkIjpudWxsLCJidWNrZXRfbmFtZSI6ImRldmluYXR0YWNobWVudHMiLCJidWNrZXRfa2V5IjoiYXR0YWNobWVudHNfcHJpdmF0ZS9vcmctYzA4ZWNhZTVlODUwNGJlY2I0MWE1NmY1ZGYwYjE2N2UvMjJiMmI3NGYtMDQ1OC00MjYzLTgyOWEtMDQzM2EwZTRlMmZkIiwiaWF0IjoxNzg2MzE2NzA2LCJleHAiOjE3ODY5MjE1MDYsImZpbGVuYW1lIjoic3NfODY2ZjliOWIucG5nIn0.rsu3cacLlipFoE_6Cn43pDtpAwbUdOXY3xGFKxKe5iw)

Note: the page will 500 until blitz-wpt-results#1 lands (no `summary.json` on main yet), so merge that first.

Link to Devin session: https://app.devin.ai/sessions/d987ba933f534a0a808775b74506f112
Requested by: @nicoburns