### PR TITLE
Add history charts to WPT pages

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -21,7 +21,7 @@ use downloads::{load_downloads, DOWNLOAD_CACHE};
 use routes::{
     AboutPage, ArcDownloadLinks, CssSupportPage, DownloadsPage, DownloadsPageProps,
     ElementSupportPage, EventSupportPage, GettingStartedPage, HomePage, NLNetInstructionsPage,
-    WptResultsPage, WptResultsPageProps,
+    WptHistoryPage, WptHistoryPageProps, WptResultsPage, WptResultsPageProps,
 };
 use serde::Deserialize;
 use std::{
@@ -32,12 +32,14 @@ use std::{
 use tokio::net::TcpListener;
 use tower_http::{services::ServeDir, trace::TraceLayer};
 use wpt::{load_wpt_results, WPT_REPORT_CACHE};
+use wpt_history::{load_wpt_history, WPT_HISTORY_CACHE};
 
 mod components;
 mod downloads;
 mod github;
 mod routes;
 mod wpt;
+mod wpt_history;
 
 #[derive(Deserialize)]
 struct DownloadLinkKey {
@@ -146,6 +148,41 @@ async fn main() {
                 };
 
                 dx_route_with_props(WptResultsPage, props).await
+            }),
+        )
+        .route(
+            "/status/wpt/history",
+            get(async || {
+                let now = Instant::now();
+                let cache_entry = WPT_HISTORY_CACHE.get_cloned();
+                let etag = cache_entry.as_ref().and_then(|entry| entry.etag.clone());
+
+                // Cache with 30s validity
+                let mut await_revalidation = true;
+                if let Some(entry) = &cache_entry {
+                    let cache_age = now.duration_since(entry.cached_at);
+                    if cache_age <= Duration::from_secs(30) {
+                        let props = WptHistoryPageProps {
+                            summary: entry.summary.clone(),
+                        };
+                        return dx_route_with_props(WptHistoryPage, props).await;
+                    } else if cache_age <= Duration::from_mins(30) {
+                        await_revalidation = false
+                    }
+                }
+
+                let handle = tokio::spawn(async move { load_wpt_history(etag).await });
+
+                if await_revalidation {
+                    handle.await.unwrap();
+                }
+
+                let entry = WPT_HISTORY_CACHE.get_cloned().unwrap();
+                let props = WptHistoryPageProps {
+                    summary: entry.summary.clone(),
+                };
+
+                dx_route_with_props(WptHistoryPage, props).await
             }),
         )
         .route(

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,7 +18,7 @@ use dashmap::DashMap;
 use dioxus::{core::ComponentFunction, prelude::*};
 use dioxus_html_macro::html;
 use downloads::{load_downloads, DOWNLOAD_CACHE};
-use routes::{child_areas, folder_chart_areas};
+use routes::child_areas;
 use routes::{
     AboutPage, ArcDownloadLinks, ArcWptHistory, ChartRange, CssSupportPage, DownloadsPage,
     DownloadsPageProps, ElementSupportPage, EventSupportPage, GettingStartedPage, HomePage,
@@ -160,15 +160,9 @@ async fn main() {
 
                     if entry.scores.contains_key(&area) {
                         let range = ChartRange::from_query(query.range.as_deref());
-                        // Top-level suite pages chart the suite plus its
-                        // largest children; deeper folder pages chart a
-                        // single line for the folder itself
-                        let history_areas = if area.contains('/') {
-                            vec![area.clone()]
-                        } else {
-                            folder_chart_areas(&entry.scores.0, &area)
-                        };
-                        let history = fresh_wpt_history(history_areas).await;
+                        // Folder pages chart a single line for the folder
+                        // itself
+                        let history = fresh_wpt_history(vec![area.clone()]).await;
                         let props = WptResultsPageProps {
                             report: entry.report.clone(),
                             scores: entry.scores.clone(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -122,23 +122,7 @@ async fn main() {
         )
         .route(
             "/status/wpt",
-            get(async |query: Query<WptPageQuery>| {
-                let range = ChartRange::from_query(query.range.as_deref());
-                let entry = fresh_wpt_cache_entry().await;
-                let areas = folder_chart_areas(&entry.scores.0, "css");
-                let history = fresh_wpt_history(areas).await;
-                let props = WptResultsPageProps {
-                    report: entry.report.clone(),
-                    scores: entry.scores.clone(),
-                    commit_info: entry.commit_info.clone(),
-                    area: None,
-                    history,
-                    range,
-                };
-                dx_route_with_props(WptResultsPage, props)
-                    .await
-                    .into_response()
-            }),
+            get(|| async { Redirect::to("/status/wpt/css") }),
         )
         .route(
             "/status/wpt/history",
@@ -176,14 +160,20 @@ async fn main() {
 
                     if entry.scores.contains_key(&area) {
                         let range = ChartRange::from_query(query.range.as_deref());
-                        // Folder pages chart a single line for the folder
-                        // itself
-                        let history = fresh_wpt_history(vec![area.clone()]).await;
+                        // Top-level suite pages chart the suite plus its
+                        // largest children; deeper folder pages chart a
+                        // single line for the folder itself
+                        let history_areas = if area.contains('/') {
+                            vec![area.clone()]
+                        } else {
+                            folder_chart_areas(&entry.scores.0, &area)
+                        };
+                        let history = fresh_wpt_history(history_areas).await;
                         let props = WptResultsPageProps {
                             report: entry.report.clone(),
                             scores: entry.scores.clone(),
                             commit_info: entry.commit_info.clone(),
-                            area: Some(area),
+                            area,
                             history,
                             range,
                         };

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 use axum::{
     body::{Body, Bytes},
-    extract::Query,
+    extract::{Path, Query},
     http::{header, StatusCode},
     response::{AppendHeaders, Html, IntoResponse, Redirect},
     routing::{get, get_service},
@@ -19,20 +19,21 @@ use dioxus::{core::ComponentFunction, prelude::*};
 use dioxus_html_macro::html;
 use downloads::{load_downloads, DOWNLOAD_CACHE};
 use routes::{
-    AboutPage, ArcDownloadLinks, ChartRange, CssSupportPage, DownloadsPage, DownloadsPageProps,
-    ElementSupportPage, EventSupportPage, GettingStartedPage, HomePage, NLNetInstructionsPage,
-    WptHistoryPage, WptHistoryPageProps, WptResultsPage, WptResultsPageProps,
+    AboutPage, ArcDownloadLinks, ArcWptHistory, ChartRange, CssSupportPage, DownloadsPage,
+    DownloadsPageProps, ElementSupportPage, EventSupportPage, GettingStartedPage, HomePage,
+    NLNetInstructionsPage, WptFolderPage, WptFolderPageProps, WptHistoryPage, WptHistoryPageProps,
+    WptResultsPage, WptResultsPageProps,
 };
 use serde::Deserialize;
 use std::{
     net::{IpAddr, SocketAddr},
-    sync::LazyLock,
+    sync::{Arc, LazyLock},
     time::{Duration, Instant},
 };
 use tokio::net::TcpListener;
 use tower_http::{services::ServeDir, trace::TraceLayer};
 use wpt::{load_wpt_results, WPT_REPORT_CACHE};
-use wpt_history::{load_wpt_history, WPT_HISTORY_CACHE};
+use wpt_history::{history_group, load_wpt_history, WPT_HISTORY_CACHE};
 
 mod components;
 mod downloads;
@@ -118,82 +119,69 @@ async fn main() {
         )
         .route(
             "/status/wpt",
-            get(async || {
-                let now = Instant::now();
-                let cache_entry = WPT_REPORT_CACHE.get_cloned();
-                let etag = cache_entry.as_ref().and_then(|entry| entry.etag.clone());
-
-                // Cache with 30s validity
-                let mut await_revalidation = true;
-                if let Some(entry) = &cache_entry {
-                    let cache_age = now.duration_since(entry.cached_at);
-                    if cache_age <= Duration::from_secs(30) {
-                        let props = WptResultsPageProps {
-                            report: entry.report.clone(),
-                            scores: entry.scores.clone(),
-                            commit_info: entry.commit_info.clone(),
-                        };
-                        return dx_route_with_props(WptResultsPage, props).await;
-                    } else if cache_age <= Duration::from_mins(30) {
-                        await_revalidation = false
-                    }
-                }
-
-                let handle = tokio::spawn(async move { load_wpt_results(etag).await });
-
-                if await_revalidation {
-                    handle.await.unwrap();
-                }
-
-                let entry = WPT_REPORT_CACHE.get_cloned().unwrap();
+            get(async |query: Query<WptHistoryQuery>| {
+                let range = ChartRange::from_query(query.range.as_deref());
+                let (report_entry, history) =
+                    tokio::join!(fresh_wpt_report(), fresh_wpt_history("css"));
                 let props = WptResultsPageProps {
-                    report: entry.report.clone(),
-                    scores: entry.scores.clone(),
-                    commit_info: entry.commit_info.clone(),
+                    report: report_entry.report.clone(),
+                    scores: report_entry.scores.clone(),
+                    commit_info: report_entry.commit_info.clone(),
+                    history,
+                    range,
                 };
-
-                dx_route_with_props(WptResultsPage, props).await
+                dx_route_with_props(WptResultsPage, props)
+                    .await
+                    .into_response()
             }),
         )
         .route(
             "/status/wpt/history",
             get(async |query: Query<WptHistoryQuery>| {
                 let range = ChartRange::from_query(query.range.as_deref());
-                let now = Instant::now();
-                let cache_entry = WPT_HISTORY_CACHE.get_cloned();
-                let etag = cache_entry.as_ref().and_then(|entry| entry.etag.clone());
-
-                // Cache with 30s validity
-                let mut await_revalidation = true;
-                if let Some(entry) = &cache_entry {
-                    let cache_age = now.duration_since(entry.cached_at);
-                    if cache_age <= Duration::from_secs(30) {
-                        let props = WptHistoryPageProps {
-                            summary: entry.summary.clone(),
-                            range,
-                            commit_messages: entry.commit_messages.clone(),
-                        };
-                        return dx_route_with_props(WptHistoryPage, props).await;
-                    } else if cache_age <= Duration::from_mins(30) {
-                        await_revalidation = false
-                    }
-                }
-
-                let handle = tokio::spawn(async move { load_wpt_history(etag).await });
-
-                if await_revalidation {
-                    handle.await.unwrap();
-                }
-
-                let entry = WPT_HISTORY_CACHE.get_cloned().unwrap();
-                let props = WptHistoryPageProps {
-                    summary: entry.summary.clone(),
-                    range,
-                    commit_messages: entry.commit_messages.clone(),
+                let Some(history) = fresh_wpt_history("css").await else {
+                    return (
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        Html("History data not available".to_string()),
+                    )
+                        .into_response();
                 };
-
-                dx_route_with_props(WptHistoryPage, props).await
+                let props = WptHistoryPageProps { history, range };
+                dx_route_with_props(WptHistoryPage, props)
+                    .await
+                    .into_response()
             }),
+        )
+        .route(
+            "/status/wpt/{*folder}",
+            get(
+                async |Path(folder): Path<String>, query: Query<WptHistoryQuery>| {
+                    let range = ChartRange::from_query(query.range.as_deref());
+                    let folder = folder.trim_matches('/').to_string();
+                    let group = history_group(&folder).to_string();
+                    let (report_entry, history) =
+                        tokio::join!(fresh_wpt_report(), fresh_wpt_history(&group));
+
+                    if !report_entry.scores.contains_key(&folder) {
+                        return (
+                            StatusCode::NOT_FOUND,
+                            Html(format!("Unknown WPT folder: {folder}")),
+                        )
+                            .into_response();
+                    }
+
+                    let props = WptFolderPageProps {
+                        folder,
+                        scores: report_entry.scores.clone(),
+                        commit_info: report_entry.commit_info.clone(),
+                        history,
+                        range,
+                    };
+                    dx_route_with_props(WptFolderPage, props)
+                        .await
+                        .into_response()
+                },
+            ),
         )
         .route(
             "/downloads",
@@ -269,6 +257,7 @@ async fn main() {
 
     // Prime WPT result and download caches
     tokio::spawn(async move { load_wpt_results(None).await });
+    tokio::spawn(async move { load_wpt_history("css".to_string()).await });
 
     if std::env::var("PRECACHE_DOWNLOADS").is_ok() {
         tokio::spawn(async move { load_downloads(None).await });
@@ -280,6 +269,59 @@ async fn main() {
     axum::serve(listener, app.into_make_service())
         .await
         .unwrap();
+}
+
+/// Get the latest WPT report cache entry, refreshing it if it is stale
+/// (serve directly for 30s; serve stale-while-revalidate for 30min)
+async fn fresh_wpt_report() -> Arc<wpt::WptReportCacheEntry> {
+    let now = Instant::now();
+    let cache_entry = WPT_REPORT_CACHE.get_cloned();
+    let etag = cache_entry.as_ref().and_then(|entry| entry.etag.clone());
+
+    let mut await_revalidation = true;
+    if let Some(entry) = cache_entry {
+        let cache_age = now.duration_since(entry.cached_at);
+        if cache_age <= Duration::from_secs(30) {
+            return entry;
+        } else if cache_age <= Duration::from_mins(30) {
+            await_revalidation = false
+        }
+    }
+
+    let handle = tokio::spawn(async move { load_wpt_results(etag).await });
+    if await_revalidation {
+        handle.await.unwrap();
+    }
+
+    WPT_REPORT_CACHE.get_cloned().unwrap()
+}
+
+/// Get the latest WPT history data for a group, refreshing it if it is stale
+/// (serve directly for 30s; serve stale-while-revalidate for 30min)
+async fn fresh_wpt_history(group: &str) -> Option<ArcWptHistory> {
+    let now = Instant::now();
+    let cache_entry = WPT_HISTORY_CACHE.get_cloned(group);
+
+    let mut await_revalidation = true;
+    if let Some(entry) = cache_entry {
+        let cache_age = now.duration_since(entry.cached_at);
+        if cache_age <= Duration::from_secs(30) {
+            return Some(entry.history.clone());
+        } else if cache_age <= Duration::from_mins(30) {
+            await_revalidation = false
+        }
+    }
+
+    let group = group.to_string();
+    let handle = {
+        let group = group.clone();
+        tokio::spawn(async move { load_wpt_history(group).await })
+    };
+    if await_revalidation {
+        let _ = handle.await;
+    }
+
+    Some(WPT_HISTORY_CACHE.get_cloned(&group)?.history.clone())
 }
 
 async fn dx_route_cached(render_fn: fn() -> Element) -> impl IntoResponse {

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,7 +19,7 @@ use dioxus::{core::ComponentFunction, prelude::*};
 use dioxus_html_macro::html;
 use downloads::{load_downloads, DOWNLOAD_CACHE};
 use routes::{
-    AboutPage, ArcDownloadLinks, CssSupportPage, DownloadsPage, DownloadsPageProps,
+    AboutPage, ArcDownloadLinks, ChartRange, CssSupportPage, DownloadsPage, DownloadsPageProps,
     ElementSupportPage, EventSupportPage, GettingStartedPage, HomePage, NLNetInstructionsPage,
     WptHistoryPage, WptHistoryPageProps, WptResultsPage, WptResultsPageProps,
 };
@@ -40,6 +40,11 @@ mod github;
 mod routes;
 mod wpt;
 mod wpt_history;
+
+#[derive(Deserialize)]
+struct WptHistoryQuery {
+    range: Option<String>,
+}
 
 #[derive(Deserialize)]
 struct DownloadLinkKey {
@@ -152,7 +157,8 @@ async fn main() {
         )
         .route(
             "/status/wpt/history",
-            get(async || {
+            get(async |query: Query<WptHistoryQuery>| {
+                let range = ChartRange::from_query(query.range.as_deref());
                 let now = Instant::now();
                 let cache_entry = WPT_HISTORY_CACHE.get_cloned();
                 let etag = cache_entry.as_ref().and_then(|entry| entry.etag.clone());
@@ -164,6 +170,7 @@ async fn main() {
                     if cache_age <= Duration::from_secs(30) {
                         let props = WptHistoryPageProps {
                             summary: entry.summary.clone(),
+                            range,
                         };
                         return dx_route_with_props(WptHistoryPage, props).await;
                     } else if cache_age <= Duration::from_mins(30) {
@@ -180,6 +187,7 @@ async fn main() {
                 let entry = WPT_HISTORY_CACHE.get_cloned().unwrap();
                 let props = WptHistoryPageProps {
                     summary: entry.summary.clone(),
+                    range,
                 };
 
                 dx_route_with_props(WptHistoryPage, props).await

--- a/src/main.rs
+++ b/src/main.rs
@@ -171,6 +171,7 @@ async fn main() {
                         let props = WptHistoryPageProps {
                             summary: entry.summary.clone(),
                             range,
+                            commit_messages: entry.commit_messages.clone(),
                         };
                         return dx_route_with_props(WptHistoryPage, props).await;
                     } else if cache_age <= Duration::from_mins(30) {
@@ -188,6 +189,7 @@ async fn main() {
                 let props = WptHistoryPageProps {
                     summary: entry.summary.clone(),
                     range,
+                    commit_messages: entry.commit_messages.clone(),
                 };
 
                 dx_route_with_props(WptHistoryPage, props).await

--- a/src/main.rs
+++ b/src/main.rs
@@ -122,7 +122,7 @@ async fn main() {
             get(async |query: Query<WptHistoryQuery>| {
                 let range = ChartRange::from_query(query.range.as_deref());
                 let (report_entry, history) =
-                    tokio::join!(fresh_wpt_report(), fresh_wpt_history("css"));
+                    tokio::join!(fresh_wpt_report(), fresh_wpt_history("css/css"));
                 let props = WptResultsPageProps {
                     report: report_entry.report.clone(),
                     scores: report_entry.scores.clone(),
@@ -139,7 +139,7 @@ async fn main() {
             "/status/wpt/history",
             get(async |query: Query<WptHistoryQuery>| {
                 let range = ChartRange::from_query(query.range.as_deref());
-                let Some(history) = fresh_wpt_history("css").await else {
+                let Some(history) = fresh_wpt_history("css/css").await else {
                     return (
                         StatusCode::INTERNAL_SERVER_ERROR,
                         Html("History data not available".to_string()),
@@ -158,7 +158,7 @@ async fn main() {
                 async |Path(folder): Path<String>, query: Query<WptHistoryQuery>| {
                     let range = ChartRange::from_query(query.range.as_deref());
                     let folder = folder.trim_matches('/').to_string();
-                    let group = history_group(&folder).to_string();
+                    let group = history_group(&folder);
                     let (report_entry, history) =
                         tokio::join!(fresh_wpt_report(), fresh_wpt_history(&group));
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,7 @@ use dashmap::DashMap;
 use dioxus::{core::ComponentFunction, prelude::*};
 use dioxus_html_macro::html;
 use downloads::{load_downloads, DOWNLOAD_CACHE};
+use routes::{child_areas, folder_chart_areas};
 use routes::{
     AboutPage, ArcDownloadLinks, ArcWptHistory, ChartRange, CssSupportPage, DownloadsPage,
     DownloadsPageProps, ElementSupportPage, EventSupportPage, GettingStartedPage, HomePage,
@@ -33,7 +34,7 @@ use std::{
 use tokio::net::TcpListener;
 use tower_http::{services::ServeDir, trace::TraceLayer};
 use wpt::{load_wpt_results, WPT_REPORT_CACHE};
-use wpt_history::{history_group, load_wpt_history, WPT_HISTORY_CACHE};
+use wpt_history::{load_wpt_history, WPT_HISTORY_CACHE};
 
 mod components;
 mod downloads;
@@ -121,8 +122,9 @@ async fn main() {
             "/status/wpt",
             get(async |query: Query<WptHistoryQuery>| {
                 let range = ChartRange::from_query(query.range.as_deref());
-                let (report_entry, history) =
-                    tokio::join!(fresh_wpt_report(), fresh_wpt_history("css/css"));
+                let report_entry = fresh_wpt_report().await;
+                let areas = folder_chart_areas(&report_entry.scores.0, "css");
+                let history = fresh_wpt_history(areas).await;
                 let props = WptResultsPageProps {
                     report: report_entry.report.clone(),
                     scores: report_entry.scores.clone(),
@@ -139,7 +141,17 @@ async fn main() {
             "/status/wpt/history",
             get(async |query: Query<WptHistoryQuery>| {
                 let range = ChartRange::from_query(query.range.as_deref());
-                let Some(history) = fresh_wpt_history("css/css").await else {
+                // The history page charts "css" plus every one of its
+                // direct children (sparklines show them all)
+                let report_entry = fresh_wpt_report().await;
+                let mut areas = vec!["css".to_string()];
+                areas.extend(
+                    child_areas(&report_entry.scores.0, "css")
+                        .into_iter()
+                        .map(|(area, _)| area),
+                );
+                areas[1..].sort();
+                let Some(history) = fresh_wpt_history(areas).await else {
                     return (
                         StatusCode::INTERNAL_SERVER_ERROR,
                         Html("History data not available".to_string()),
@@ -158,9 +170,9 @@ async fn main() {
                 async |Path(folder): Path<String>, query: Query<WptHistoryQuery>| {
                     let range = ChartRange::from_query(query.range.as_deref());
                     let folder = folder.trim_matches('/').to_string();
-                    let group = history_group(&folder);
-                    let (report_entry, history) =
-                        tokio::join!(fresh_wpt_report(), fresh_wpt_history(&group));
+                    let report_entry = fresh_wpt_report().await;
+                    // Folder pages chart a single line for the folder itself
+                    let history = fresh_wpt_history(vec![folder.clone()]).await;
 
                     if !report_entry.scores.contains_key(&folder) {
                         return (
@@ -257,7 +269,7 @@ async fn main() {
 
     // Prime WPT result and download caches
     tokio::spawn(async move { load_wpt_results(None).await });
-    tokio::spawn(async move { load_wpt_history("css".to_string()).await });
+    tokio::spawn(async move { load_wpt_history(vec!["css".to_string()]).await });
 
     if std::env::var("PRECACHE_DOWNLOADS").is_ok() {
         tokio::spawn(async move { load_downloads(None).await });
@@ -296,32 +308,34 @@ async fn fresh_wpt_report() -> Arc<wpt::WptReportCacheEntry> {
     WPT_REPORT_CACHE.get_cloned().unwrap()
 }
 
-/// Get the latest WPT history data for a group, refreshing it if it is stale
-/// (serve directly for 30s; serve stale-while-revalidate for 30min)
-async fn fresh_wpt_history(group: &str) -> Option<ArcWptHistory> {
+/// Get the latest WPT history data for a set of areas, refreshing it if it
+/// is stale (serve directly for 30s; serve stale-while-revalidate for 30min).
+/// A refresh only revalidates runs.json (all summary files change together),
+/// so cached areas are reused and only missing area files are fetched.
+async fn fresh_wpt_history(areas: Vec<String>) -> Option<ArcWptHistory> {
     let now = Instant::now();
-    let cache_entry = WPT_HISTORY_CACHE.get_cloned(group);
 
     let mut await_revalidation = true;
-    if let Some(entry) = cache_entry {
-        let cache_age = now.duration_since(entry.cached_at);
-        if cache_age <= Duration::from_secs(30) {
-            return Some(entry.history.clone());
-        } else if cache_age <= Duration::from_mins(30) {
-            await_revalidation = false
+    if let Some(entry) = WPT_HISTORY_CACHE.get_cloned() {
+        if entry.contains_areas(&areas) {
+            let cache_age = now.duration_since(entry.cached_at);
+            if cache_age <= Duration::from_secs(30) {
+                return Some(entry.merged(&areas));
+            } else if cache_age <= Duration::from_mins(30) {
+                await_revalidation = false
+            }
         }
     }
 
-    let group = group.to_string();
     let handle = {
-        let group = group.clone();
-        tokio::spawn(async move { load_wpt_history(group).await })
+        let areas = areas.clone();
+        tokio::spawn(async move { load_wpt_history(areas).await })
     };
     if await_revalidation {
         let _ = handle.await;
     }
 
-    Some(WPT_HISTORY_CACHE.get_cloned(&group)?.history.clone())
+    Some(WPT_HISTORY_CACHE.get_cloned()?.merged(&areas))
 }
 
 async fn dx_route_cached(render_fn: fn() -> Element) -> impl IntoResponse {

--- a/src/routes/mod.rs
+++ b/src/routes/mod.rs
@@ -6,3 +6,4 @@ mod downloads;          pub use downloads::*;
 mod about;              pub use about::*;
 mod nlnet_instructions; pub use nlnet_instructions::*;
 mod wpt;                pub use wpt::*;
+mod wpt_history;        pub use wpt_history::*;

--- a/src/routes/support_matrix.rs
+++ b/src/routes/support_matrix.rs
@@ -63,6 +63,10 @@ pub fn StatusTabs(current_tab: &'static str) -> Element {
             href: "/status/wpt",
             label: "WPT Tests",
         },
+        Tab {
+            href: "/status/wpt/history",
+            label: "WPT History",
+        },
     ];
 
     rsx!(

--- a/src/routes/wpt.rs
+++ b/src/routes/wpt.rs
@@ -153,8 +153,11 @@ fn FolderHistoryChart(
     }];
 
     rsx! {
-        ChartRangeSelector { current_range: range, base_path }
-        WptHistoryChart { history, series_spec, range, height: 240.0 }
+        details {
+            summary { "Score history" }
+            ChartRangeSelector { current_range: range, base_path }
+            WptHistoryChart { history, series_spec, range, height: 240.0 }
+        }
     }
 }
 

--- a/src/routes/wpt.rs
+++ b/src/routes/wpt.rs
@@ -86,9 +86,6 @@ pub fn WptResultsPage(
     history: Option<ArcWptHistory>,
     range: ChartRange,
 ) -> Element {
-    // Top-level suite pages (e.g. "css") get the full-size multi-series
-    // chart; deeper folder pages get the compact single-line chart
-    let compact = area.contains('/');
     rsx! {
         Page { title: "Status: WPT".into(),
             StatusHeader {}
@@ -107,29 +104,14 @@ pub fn WptResultsPage(
             WptBreadcrumb { area: area.clone() }
             FolderHistoryChart {
                 folder: area.clone(),
-                scores: scores.clone(),
                 history,
                 range,
                 base_path: "/status/wpt/{area}",
-                compact,
             }
             CommitInfoDisplay { commit_info, label: "Data from commit:" }
             WptAreaResults { report, scores, area }
         }
     }
-}
-
-/// The areas charted on a folder's full-size history chart: the folder
-/// itself plus its largest direct children (one per available line color)
-pub fn folder_chart_areas(scores: &WptScores, folder: &str) -> Vec<String> {
-    std::iter::once(folder.to_string())
-        .chain(
-            child_areas(scores, folder)
-                .into_iter()
-                .take(SERIES_COLORS.len() - 1)
-                .map(|(area, _)| area),
-        )
-        .collect()
 }
 
 /// The direct child areas of a folder, largest (by subtest count) first
@@ -147,23 +129,20 @@ pub fn child_areas(scores: &WptScores, folder: &str) -> Vec<(String, AreaScores)
     children
 }
 
-/// A history chart for a folder. Compact charts show a single short line for
-/// the folder's total; full-size charts also show a line for each of the
-/// folder's largest direct children.
+/// A short history chart for a folder, showing a single line for the
+/// folder's total
 #[component]
 fn FolderHistoryChart(
     folder: String,
-    scores: ArcWptScores,
     history: Option<ArcWptHistory>,
     range: ChartRange,
     base_path: String,
-    #[props(default = false)] compact: bool,
 ) -> Element {
     let Some(history) = history else {
         return rsx!( p { "No history data available" } );
     };
 
-    let mut series_spec = vec![ChartSeries {
+    let series_spec = vec![ChartSeries {
         area: folder.clone(),
         label: if folder == "css" {
             "all css".to_string()
@@ -172,25 +151,10 @@ fn FolderHistoryChart(
         },
         color: SERIES_COLORS[0],
     }];
-    if !compact {
-        let prefix = format!("{folder}/");
-        for (child, _) in child_areas(&scores, &folder)
-            .into_iter()
-            .take(SERIES_COLORS.len() - 1)
-        {
-            series_spec.push(ChartSeries {
-                label: child.strip_prefix(&prefix).unwrap_or(&child).to_string(),
-                area: child,
-                color: SERIES_COLORS[series_spec.len()],
-            });
-        }
-    }
-
-    let height = if compact { 240.0 } else { 440.0 };
 
     rsx! {
         ChartRangeSelector { current_range: range, base_path }
-        WptHistoryChart { history, series_spec, range, height }
+        WptHistoryChart { history, series_spec, range, height: 240.0 }
     }
 }
 

--- a/src/routes/wpt.rs
+++ b/src/routes/wpt.rs
@@ -82,10 +82,13 @@ pub fn WptResultsPage(
     report: ArcWptReport,
     scores: ArcWptScores,
     commit_info: Option<CommitInfo>,
-    area: Option<String>,
+    area: String,
     history: Option<ArcWptHistory>,
     range: ChartRange,
 ) -> Element {
+    // Top-level suite pages (e.g. "css") get the full-size multi-series
+    // chart; deeper folder pages get the compact single-line chart
+    let compact = area.contains('/');
     rsx! {
         Page { title: "Status: WPT".into(),
             StatusHeader {}
@@ -101,23 +104,17 @@ pub fn WptResultsPage(
                 "
             }
             hr {}
-            if let Some(area) = area {
-                WptBreadcrumb { area: area.clone() }
-                FolderHistoryChart {
-                    folder: area.clone(),
-                    scores: scores.clone(),
-                    history,
-                    range,
-                    base_path: "/status/wpt/{area}",
-                    compact: true,
-                }
-                CommitInfoDisplay { commit_info, label: "Data from commit:" }
-                WptAreaResults { report, scores, area }
-            } else {
-                FolderHistoryChart { folder: "css", scores: scores.clone(), history, range, base_path: "/status/wpt" }
-                CommitInfoDisplay { commit_info, label: "Data from commit:" }
-                WptResults { scores }
+            WptBreadcrumb { area: area.clone() }
+            FolderHistoryChart {
+                folder: area.clone(),
+                scores: scores.clone(),
+                history,
+                range,
+                base_path: "/status/wpt/{area}",
+                compact,
             }
+            CommitInfoDisplay { commit_info, label: "Data from commit:" }
+            WptAreaResults { report, scores, area }
         }
     }
 }
@@ -195,33 +192,6 @@ fn FolderHistoryChart(
         ChartRangeSelector { current_range: range, base_path }
         WptHistoryChart { history, series_spec, range, height }
     }
-}
-
-fn is_focus_area(area: &str) -> bool {
-    let slash_count = area.chars().filter(|c| *c == '/').count();
-    slash_count < 2
-}
-
-#[component]
-pub fn WptResults(scores: ArcWptScores) -> Element {
-    rsx!(
-        table {
-            width: "100%",
-            tr {
-                th { width: "min-content", "Area",  }
-                th { "Interop Score", }
-                th { "Tests", }
-                th { "Test %", }
-                th { "Subtests" }
-                th { "Subtest %" }
-            }
-            {
-                scores.iter().filter(|(area, _)| is_focus_area(area)).map(|(area, scores)| {
-                    area_score_row(area.clone(), Some(format!("/status/wpt/{area}")), *scores)
-                })
-            }
-        }
-    )
 }
 
 #[component]

--- a/src/routes/wpt.rs
+++ b/src/routes/wpt.rs
@@ -145,8 +145,21 @@ pub fn WptFolderPage(
     }
 }
 
+/// The areas charted on a folder's full-size history chart: the folder
+/// itself plus its largest direct children (one per available line color)
+pub fn folder_chart_areas(scores: &WptScores, folder: &str) -> Vec<String> {
+    std::iter::once(folder.to_string())
+        .chain(
+            child_areas(scores, folder)
+                .into_iter()
+                .take(SERIES_COLORS.len() - 1)
+                .map(|(area, _)| area),
+        )
+        .collect()
+}
+
 /// The direct child areas of a folder, largest (by subtest count) first
-fn child_areas(scores: &WptScores, folder: &str) -> Vec<(String, AreaScores)> {
+pub fn child_areas(scores: &WptScores, folder: &str) -> Vec<(String, AreaScores)> {
     let prefix = format!("{folder}/");
     let mut children: Vec<(String, AreaScores)> = scores
         .iter()

--- a/src/routes/wpt.rs
+++ b/src/routes/wpt.rs
@@ -6,7 +6,10 @@ use wptreport::{wpt_report::WptReport, AreaScores};
 use crate::{
     components::{CommitInfoDisplay, Page},
     github::CommitInfo,
-    routes::{StatusHeader, StatusTabs},
+    routes::{
+        ArcWptHistory, ChartRange, ChartRangeSelector, ChartSeries, StatusHeader, StatusTabs,
+        WptHistoryChart, SERIES_COLORS,
+    },
 };
 
 struct Colors(&'static [[u8; 3]]);
@@ -70,6 +73,8 @@ pub fn WptResultsPage(
     report: ArcWptReport,
     scores: ArcWptScores,
     commit_info: Option<CommitInfo>,
+    history: Option<ArcWptHistory>,
+    range: ChartRange,
 ) -> Element {
     rsx! {
         Page { title: "Status: WPT".into(),
@@ -86,10 +91,123 @@ pub fn WptResultsPage(
                 "
             }
             hr {}
+            FolderHistoryChart { folder: "css", scores: scores.clone(), history, range, base_path: "/status/wpt" }
             CommitInfoDisplay { commit_info, label: "Data from commit:" }
             WptResults { scores }
         }
     }
+}
+
+#[component]
+pub fn WptFolderPage(
+    folder: String,
+    scores: ArcWptScores,
+    commit_info: Option<CommitInfo>,
+    history: Option<ArcWptHistory>,
+    range: ChartRange,
+) -> Element {
+    // Breadcrumb segments: (path-so-far, segment name)
+    let crumbs: Vec<(String, String)> = folder
+        .split('/')
+        .scan(String::new(), |path, segment| {
+            if !path.is_empty() {
+                path.push('/');
+            }
+            path.push_str(segment);
+            Some((path.clone(), segment.to_string()))
+        })
+        .collect();
+
+    rsx! {
+        Page { title: "Status: WPT: {folder}".into(),
+            StatusHeader {}
+            StatusTabs { current_tab: "wpt" }
+            p {
+                font_size: "18px",
+                a { href: "/status/wpt", "wpt" }
+                for (path, segment) in crumbs {
+                    " / "
+                    a { href: "/status/wpt/{path}", {segment} }
+                }
+            }
+            hr {}
+            FolderHistoryChart {
+                folder: folder.clone(),
+                scores: scores.clone(),
+                history,
+                range,
+                base_path: "/status/wpt/{folder}",
+            }
+            CommitInfoDisplay { commit_info, label: "Data from commit:" }
+            WptFolderResults { folder, scores }
+        }
+    }
+}
+
+/// The direct child areas of a folder, largest (by subtest count) first
+fn child_areas(scores: &WptScores, folder: &str) -> Vec<(String, AreaScores)> {
+    let prefix = format!("{folder}/");
+    let mut children: Vec<(String, AreaScores)> = scores
+        .iter()
+        .filter(|(area, _)| {
+            area.strip_prefix(&prefix)
+                .is_some_and(|rest| !rest.contains('/'))
+        })
+        .map(|(area, scores)| (area.clone(), *scores))
+        .collect();
+    children.sort_by_key(|(_, scores)| std::cmp::Reverse(scores.subtests.total));
+    children
+}
+
+/// A history chart for a folder: one line for the folder itself plus one for
+/// each of its largest direct children
+#[component]
+fn FolderHistoryChart(
+    folder: String,
+    scores: ArcWptScores,
+    history: Option<ArcWptHistory>,
+    range: ChartRange,
+    base_path: String,
+) -> Element {
+    let Some(history) = history else {
+        return rsx!( p { "No history data available" } );
+    };
+
+    let mut series_spec = vec![ChartSeries {
+        area: folder.clone(),
+        label: if folder == "css" {
+            "all css".to_string()
+        } else {
+            folder.clone()
+        },
+        color: SERIES_COLORS[0],
+    }];
+    let prefix = format!("{folder}/");
+    for (child, _) in child_areas(&scores, &folder)
+        .into_iter()
+        .take(SERIES_COLORS.len() - 1)
+    {
+        series_spec.push(ChartSeries {
+            label: child.strip_prefix(&prefix).unwrap_or(&child).to_string(),
+            area: child,
+            color: SERIES_COLORS[series_spec.len()],
+        });
+    }
+
+    rsx! {
+        ChartRangeSelector { current_range: range, base_path }
+        WptHistoryChart { history, series_spec, range }
+    }
+}
+
+#[component]
+pub fn WptFolderResults(folder: String, scores: ArcWptScores) -> Element {
+    let mut areas: Vec<(String, AreaScores)> = child_areas(&scores, &folder);
+    if let Some(own) = scores.get(&folder) {
+        areas.insert(0, (folder, *own));
+    }
+    areas.sort_by(|(a, _), (b, _)| a.cmp(b));
+    wpt_score_table(areas)
 }
 
 fn is_focus_area(area: &str) -> bool {
@@ -99,6 +217,15 @@ fn is_focus_area(area: &str) -> bool {
 
 #[component]
 pub fn WptResults(scores: ArcWptScores) -> Element {
+    let areas: Vec<(String, AreaScores)> = scores
+        .iter()
+        .filter(|(area, _)| is_focus_area(area))
+        .map(|(area, scores)| (area.clone(), *scores))
+        .collect();
+    wpt_score_table(areas)
+}
+
+fn wpt_score_table(areas: Vec<(String, AreaScores)>) -> Element {
     rsx!(
         table {
             width: "100%",
@@ -111,7 +238,7 @@ pub fn WptResults(scores: ArcWptScores) -> Element {
                 th { "Subtest %" }
             }
             {
-                scores.iter().filter(|(area, _)| is_focus_area(area)).map(|(area, scores)| {
+                areas.iter().map(|(area, scores)| {
 
                     let tests = scores.tests;
                     let subtests = scores.subtests;
@@ -123,7 +250,11 @@ pub fn WptResults(scores: ArcWptScores) -> Element {
                             background_color: format!("rgb({},{},{})", color[0], color[1], color[2]),
                             td {
                                 background_color: "white",
-                                {area.clone()}
+                                a {
+                                    color: "inherit",
+                                    href: "/status/wpt/{area}",
+                                    {area.clone()}
+                                }
                             }
                             td {
                                 text_align: "right",

--- a/src/routes/wpt.rs
+++ b/src/routes/wpt.rs
@@ -137,6 +137,7 @@ pub fn WptFolderPage(
                 history,
                 range,
                 base_path: "/status/wpt/{folder}",
+                compact: true,
             }
             CommitInfoDisplay { commit_info, label: "Data from commit:" }
             WptFolderResults { folder, scores }
@@ -159,8 +160,9 @@ fn child_areas(scores: &WptScores, folder: &str) -> Vec<(String, AreaScores)> {
     children
 }
 
-/// A history chart for a folder: one line for the folder itself plus one for
-/// each of its largest direct children
+/// A history chart for a folder. Compact charts show a single short line for
+/// the folder's total; full-size charts also show a line for each of the
+/// folder's largest direct children.
 #[component]
 fn FolderHistoryChart(
     folder: String,
@@ -168,6 +170,7 @@ fn FolderHistoryChart(
     history: Option<ArcWptHistory>,
     range: ChartRange,
     base_path: String,
+    #[props(default = false)] compact: bool,
 ) -> Element {
     let Some(history) = history else {
         return rsx!( p { "No history data available" } );
@@ -182,21 +185,25 @@ fn FolderHistoryChart(
         },
         color: SERIES_COLORS[0],
     }];
-    let prefix = format!("{folder}/");
-    for (child, _) in child_areas(&scores, &folder)
-        .into_iter()
-        .take(SERIES_COLORS.len() - 1)
-    {
-        series_spec.push(ChartSeries {
-            label: child.strip_prefix(&prefix).unwrap_or(&child).to_string(),
-            area: child,
-            color: SERIES_COLORS[series_spec.len()],
-        });
+    if !compact {
+        let prefix = format!("{folder}/");
+        for (child, _) in child_areas(&scores, &folder)
+            .into_iter()
+            .take(SERIES_COLORS.len() - 1)
+        {
+            series_spec.push(ChartSeries {
+                label: child.strip_prefix(&prefix).unwrap_or(&child).to_string(),
+                area: child,
+                color: SERIES_COLORS[series_spec.len()],
+            });
+        }
     }
+
+    let height = if compact { 240.0 } else { 440.0 };
 
     rsx! {
         ChartRangeSelector { current_range: range, base_path }
-        WptHistoryChart { history, series_spec, range }
+        WptHistoryChart { history, series_spec, range, height }
     }
 }
 

--- a/src/routes/wpt_history.rs
+++ b/src/routes/wpt_history.rs
@@ -326,153 +326,6 @@ fn highlight_series() -> Vec<ChartSeries> {
         .collect()
 }
 
-/// Inline script implementing the hover tooltip as a progressive enhancement.
-/// Reads run data from the chart's JSON blob and shows the nearest run's
-/// commit id, commit message, and pass percentages for the nearest line.
-const TOOLTIP_JS: &str = r##"
-(function () {
-    var scripts = document.querySelectorAll("script[data-wpt-history-data]");
-    var dataEl = scripts[scripts.length - 1];
-    if (!dataEl) return;
-    var container = dataEl.parentElement;
-    var svg = container.querySelector("svg");
-    var data = JSON.parse(dataEl.textContent);
-    if (!svg || !data.runs.length) return;
-
-    var tip = document.createElement("div");
-    tip.style.cssText =
-        "position:absolute;pointer-events:none;display:none;background:rgba(255,255,255,0.96);" +
-        "border:1px solid #999;border-radius:4px;padding:6px 8px;font:12px sans-serif;" +
-        "box-shadow:0 1px 4px rgba(0,0,0,0.25);z-index:10;width:260px;box-sizing:border-box";
-    container.appendChild(tip);
-
-    var guide = document.createElementNS("http://www.w3.org/2000/svg", "line");
-    guide.setAttribute("stroke", "#888");
-    guide.setAttribute("stroke-dasharray", "3,3");
-    guide.setAttribute("y1", data.plot[1]);
-    guide.setAttribute("y2", data.plot[1] + data.plot[3]);
-    guide.style.display = "none";
-    svg.appendChild(guide);
-
-    var dot = document.createElementNS("http://www.w3.org/2000/svg", "circle");
-    dot.setAttribute("r", 4);
-    dot.setAttribute("stroke", "white");
-    dot.setAttribute("stroke-width", 1.5);
-    dot.style.display = "none";
-    svg.appendChild(dot);
-
-    function esc(s) {
-        return s.replace(/&/g, "&amp;").replace(/</g, "&lt;");
-    }
-
-    // Nearest hoverable run (runs before data.first only serve as deltas)
-    function nearest(x) {
-        var runs = data.runs, lo = data.first, hi = runs.length - 1;
-        while (lo < hi) {
-            var mid = (lo + hi) >> 1;
-            if (runs[mid].x < x) lo = mid + 1; else hi = mid;
-        }
-        if (lo > data.first && Math.abs(runs[lo - 1].x - x) < Math.abs(runs[lo].x - x)) lo--;
-        return lo;
-    }
-
-    function hide() {
-        tip.style.display = "none";
-        guide.style.display = "none";
-        dot.style.display = "none";
-    }
-
-    // Only show the series whose line is within this vertical distance
-    // (in viewBox units) of the cursor
-    var Y_THRESHOLD = 12;
-
-    svg.addEventListener("mousemove", function (ev) {
-        var rect = svg.getBoundingClientRect();
-        var scale = data.width / rect.width;
-        var vx = (ev.clientX - rect.left) * scale;
-        var vy = (ev.clientY - rect.top) * scale;
-        var px = data.plot[0], py = data.plot[1], pw = data.plot[2], ph = data.plot[3];
-        if (vx < px || vx > px + pw) { hide(); return; }
-
-        var xRange = data.xMax - data.xMin;
-        var runIdx = nearest(data.xMin + ((vx - px) / pw) * xRange);
-        var run = data.runs[runIdx];
-        var prev = runIdx > 0 ? data.runs[runIdx - 1] : null;
-
-        // Pick the single series whose line is vertically nearest the cursor
-        var best = -1, bestDist = Y_THRESHOLD;
-        for (var i = 0; i < data.series.length; i++) {
-            if (run.v[i] == null) continue;
-            var sy = py + (1 - (run.v[i][0] / run.v[i][1])) * ph;
-            var dist = Math.abs(sy - vy);
-            if (dist < bestDist) { best = i; bestDist = dist; }
-        }
-        if (best < 0) { hide(); return; }
-
-        // Prefer a nearby commit whose value actually changed for this
-        // series over the strictly-nearest commit
-        var SNAP_PX = 10;
-        function screenX(i) { return px + ((data.runs[i].x - data.xMin) / xRange) * pw; }
-        function hasChange(i) {
-            var cur = data.runs[i].v[best];
-            if (cur == null) return false;
-            var p = i > 0 ? data.runs[i - 1].v[best] : null;
-            return p == null || cur[0] !== p[0] || cur[1] !== p[1];
-        }
-        var snapped = -1, snappedDist = SNAP_PX;
-        for (var j = data.first; j < data.runs.length; j++) {
-            var d = Math.abs(screenX(j) - vx);
-            if (d <= snappedDist && hasChange(j)) { snapped = j; snappedDist = d; }
-        }
-        if (snapped >= 0 && !hasChange(runIdx)) {
-            runIdx = snapped;
-            run = data.runs[runIdx];
-            prev = runIdx > 0 ? data.runs[runIdx - 1] : null;
-        }
-
-        var runVx = px + ((run.x - data.xMin) / xRange) * pw;
-        guide.setAttribute("x1", runVx);
-        guide.setAttribute("x2", runVx);
-        guide.style.display = "";
-
-        dot.setAttribute("cx", runVx);
-        dot.setAttribute("cy", py + (1 - (run.v[best][0] / run.v[best][1])) * ph);
-        dot.setAttribute("fill", data.series[best].color);
-        dot.style.display = "";
-
-        var html = "<div style='font-weight:bold'>" + esc(run.sha.slice(0, 9)) + " (" + esc(run.d) + ")</div>";
-        if (run.msg) {
-            html += "<div style='margin-bottom:4px;white-space:nowrap;overflow:hidden;" +
-                "text-overflow:ellipsis'>" + esc(run.msg) + "</div>";
-        }
-        var pass = run.v[best][0], total = run.v[best][1];
-        html += "<div><span style='color:" + data.series[best].color + "'>\u25CF</span> " +
-            esc(data.series[best].name) + ": " + (100 * pass / total).toFixed(1) + "% (" +
-            pass.toLocaleString() + "/" + total.toLocaleString() + ")</div>";
-
-        // Change relative to the previous run
-        if (prev && prev.v[best] != null) {
-            var dPass = pass - prev.v[best][0];
-            var dPct = 100 * (pass / total - prev.v[best][0] / prev.v[best][1]);
-            var sign = dPass > 0 ? "+" : "";
-            var color = dPass > 0 ? "#2e7d32" : (dPass < 0 ? "#c62828" : "#666");
-            html += "<div style='color:" + color + "'>Change: " + sign +
-                dPass.toLocaleString() + " (" + sign + dPct.toFixed(2) + "%)</div>";
-        }
-        tip.innerHTML = html;
-        tip.style.display = "block";
-
-        var crect = container.getBoundingClientRect();
-        var cx = ev.clientX - crect.left, cy = ev.clientY - crect.top;
-        var left = cx + 14;
-        if (left + tip.offsetWidth > container.clientWidth) left = cx - tip.offsetWidth - 14;
-        tip.style.left = left + "px";
-        tip.style.top = (cy + 14) + "px";
-    });
-    svg.addEventListener("mouseleave", hide);
-})();
-"##;
-
 #[component]
 pub fn WptHistoryChart(
     history: ArcWptHistory,
@@ -646,7 +499,7 @@ pub fn WptHistoryChart(
             r#type: "application/json",
             dangerous_inner_html: tooltip_data,
         }
-        script { dangerous_inner_html: TOOLTIP_JS }
+        script { src: "/static/wpt-history-tooltip.js" }
         }
     }
 }
@@ -690,7 +543,10 @@ pub fn WptHistorySparklines(history: ArcWptHistory, range: ChartRange) -> Elemen
                     let latest = points.last().map(|p| p.1).unwrap_or(0.0);
 
                     rsx! {
-                        div {
+                        a {
+                            href: "/status/wpt/{area}",
+                            color: "inherit",
+                            text_decoration: "none",
                             div {
                                 display: "flex",
                                 justify_content: "space-between",

--- a/src/routes/wpt_history.rs
+++ b/src/routes/wpt_history.rs
@@ -85,6 +85,7 @@ const MONTH_NAMES: [&str; 12] = [
 
 #[derive(Copy, Clone, PartialEq, Debug, Default)]
 pub enum ChartRange {
+    Month1,
     Months3,
     Months6,
     Year1,
@@ -93,7 +94,8 @@ pub enum ChartRange {
 }
 
 impl ChartRange {
-    pub const ALL: [ChartRange; 4] = [
+    pub const ALL: [ChartRange; 5] = [
+        ChartRange::Month1,
         ChartRange::Months3,
         ChartRange::Months6,
         ChartRange::Year1,
@@ -102,6 +104,7 @@ impl ChartRange {
 
     pub fn from_query(value: Option<&str>) -> Self {
         match value {
+            Some("1m") => ChartRange::Month1,
             Some("3m") => ChartRange::Months3,
             Some("6m") => ChartRange::Months6,
             Some("1y") => ChartRange::Year1,
@@ -111,6 +114,7 @@ impl ChartRange {
 
     fn query_value(self) -> &'static str {
         match self {
+            ChartRange::Month1 => "1m",
             ChartRange::Months3 => "3m",
             ChartRange::Months6 => "6m",
             ChartRange::Year1 => "1y",
@@ -120,6 +124,7 @@ impl ChartRange {
 
     fn label(self) -> &'static str {
         match self {
+            ChartRange::Month1 => "1 month",
             ChartRange::Months3 => "3 months",
             ChartRange::Months6 => "6 months",
             ChartRange::Year1 => "1 year",
@@ -129,6 +134,7 @@ impl ChartRange {
 
     fn days(self) -> Option<f64> {
         match self {
+            ChartRange::Month1 => Some(30.0),
             ChartRange::Months3 => Some(91.0),
             ChartRange::Months6 => Some(183.0),
             ChartRange::Year1 => Some(365.0),
@@ -339,13 +345,14 @@ const TOOLTIP_JS: &str = r##"
         return s.replace(/&/g, "&amp;").replace(/</g, "&lt;");
     }
 
+    // Nearest hoverable run (runs before data.first only serve as deltas)
     function nearest(x) {
-        var runs = data.runs, lo = 0, hi = runs.length - 1;
+        var runs = data.runs, lo = data.first, hi = runs.length - 1;
         while (lo < hi) {
             var mid = (lo + hi) >> 1;
             if (runs[mid].x < x) lo = mid + 1; else hi = mid;
         }
-        if (lo > 0 && Math.abs(runs[lo - 1].x - x) < Math.abs(runs[lo].x - x)) lo--;
+        if (lo > data.first && Math.abs(runs[lo - 1].x - x) < Math.abs(runs[lo].x - x)) lo--;
         return lo;
     }
 
@@ -367,7 +374,9 @@ const TOOLTIP_JS: &str = r##"
         if (vx < px || vx > px + pw) { hide(); return; }
 
         var xRange = data.xMax - data.xMin;
-        var run = data.runs[nearest(data.xMin + ((vx - px) / pw) * xRange)];
+        var runIdx = nearest(data.xMin + ((vx - px) / pw) * xRange);
+        var run = data.runs[runIdx];
+        var prev = runIdx > 0 ? data.runs[runIdx - 1] : null;
 
         // Pick the single series whose line is vertically nearest the cursor
         var best = -1, bestDist = Y_THRESHOLD;
@@ -393,6 +402,16 @@ const TOOLTIP_JS: &str = r##"
         html += "<div><span style='color:" + data.series[best].color + "'>\u25CF</span> " +
             esc(data.series[best].name) + ": " + (100 * pass / total).toFixed(1) + "% (" +
             pass.toLocaleString() + "/" + total.toLocaleString() + ")</div>";
+
+        // Change relative to the previous run
+        if (prev && prev.v[best] != null) {
+            var dPass = pass - prev.v[best][0];
+            var dPct = 100 * (pass / total - prev.v[best][0] / prev.v[best][1]);
+            var sign = dPass > 0 ? "+" : "";
+            var color = dPass > 0 ? "#2e7d32" : (dPass < 0 ? "#c62828" : "#666");
+            html += "<div style='color:" + color + "'>\u0394 vs prev: " + sign +
+                dPass.toLocaleString() + " (" + sign + dPct.toFixed(2) + "pp)</div>";
+        }
         tip.innerHTML = html;
         tip.style.display = "block";
 
@@ -445,14 +464,18 @@ pub fn WptHistoryChart(
         .iter()
         .map(|(area, _)| summary.focus_areas.iter().position(|a| a == area))
         .collect();
-    let runs_json: Vec<serde_json::Value> = summary
+    // Include the run immediately before the visible range (if any) so the
+    // first visible run's tooltip can show a delta against it
+    let first_visible = summary
         .runs
+        .iter()
+        .position(|run| parse_date(&run.date).is_some_and(|x| x >= min_x))
+        .unwrap_or(0);
+    let start = first_visible.saturating_sub(1);
+    let runs_json: Vec<serde_json::Value> = summary.runs[start..]
         .iter()
         .filter_map(|run| {
             let x = parse_date(&run.date)?;
-            if x < min_x {
-                return None;
-            }
             let values: Vec<serde_json::Value> = area_indices
                 .iter()
                 .map(|idx| {
@@ -477,6 +500,7 @@ pub fn WptHistoryChart(
         })
         .collect();
     let tooltip_data = serde_json::json!({
+        "first": first_visible - start,
         "width": WIDTH,
         "plot": [px, py, pw, ph],
         "xMin": x_min,

--- a/src/routes/wpt_history.rs
+++ b/src/routes/wpt_history.rs
@@ -324,7 +324,7 @@ const TOOLTIP_JS: &str = r##"
     tip.style.cssText =
         "position:absolute;pointer-events:none;display:none;background:rgba(255,255,255,0.96);" +
         "border:1px solid #999;border-radius:4px;padding:6px 8px;font:12px sans-serif;" +
-        "box-shadow:0 1px 4px rgba(0,0,0,0.25);z-index:10;max-width:340px";
+        "box-shadow:0 1px 4px rgba(0,0,0,0.25);z-index:10;width:260px;box-sizing:border-box";
     container.appendChild(tip);
 
     var guide = document.createElementNS("http://www.w3.org/2000/svg", "line");
@@ -369,7 +369,10 @@ const TOOLTIP_JS: &str = r##"
         guide.style.display = "";
 
         var html = "<div style='font-weight:bold'>" + esc(run.sha.slice(0, 9)) + " (" + esc(run.d) + ")</div>";
-        if (run.msg) html += "<div style='margin-bottom:4px'>" + esc(run.msg) + "</div>";
+        if (run.msg) {
+            html += "<div style='margin-bottom:4px;white-space:nowrap;overflow:hidden;" +
+                "text-overflow:ellipsis'>" + esc(run.msg) + "</div>";
+        }
         for (var i = 0; i < data.series.length; i++) {
             if (run.v[i] == null) continue;
             html += "<div><span style='color:" + data.series[i].color + "'>\u25CF</span> " +

--- a/src/routes/wpt_history.rs
+++ b/src/routes/wpt_history.rs
@@ -7,6 +7,20 @@ use crate::routes::{StatusHeader, StatusTabs};
 use crate::components::Page;
 
 #[derive(Clone)]
+pub struct ArcCommitMessages(pub Arc<std::collections::HashMap<String, String>>);
+impl PartialEq for ArcCommitMessages {
+    fn eq(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.0, &other.0)
+    }
+}
+impl Deref for ArcCommitMessages {
+    type Target = std::collections::HashMap<String, String>;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+#[derive(Clone)]
 pub struct ArcWptSummary(pub Arc<ScoreSummaryReport>);
 impl PartialEq for ArcWptSummary {
     fn eq(&self, other: &Self) -> bool {
@@ -237,7 +251,11 @@ fn month_ticks(x_min: f64, x_max: f64) -> Vec<(f64, String)> {
 }
 
 #[component]
-pub fn WptHistoryPage(summary: ArcWptSummary, range: ChartRange) -> Element {
+pub fn WptHistoryPage(
+    summary: ArcWptSummary,
+    range: ChartRange,
+    commit_messages: ArcCommitMessages,
+) -> Element {
     rsx! {
         Page { title: "Status: WPT History".into(),
             StatusHeader {}
@@ -249,7 +267,7 @@ pub fn WptHistoryPage(summary: ArcWptSummary, range: ChartRange) -> Element {
             }
             hr {}
             ChartRangeSelector { current_range: range }
-            WptHistoryChart { summary: summary.clone(), range }
+            WptHistoryChart { summary: summary.clone(), range, commit_messages }
             h2 { "Per-area history" }
             WptHistorySparklines { summary, range }
         }
@@ -290,8 +308,93 @@ const HIGHLIGHT_AREAS: &[(&str, &str)] = &[
     ("css/css-position", "#ba68c8"),
 ];
 
+/// Inline script implementing the hover tooltip as a progressive enhancement.
+/// Reads run data from the `#wpt-history-data` JSON blob and shows the nearest
+/// run's commit id, commit message, and per-area pass percentages.
+const TOOLTIP_JS: &str = r##"
+(function () {
+    var container = document.getElementById("wpt-history-chart");
+    var dataEl = document.getElementById("wpt-history-data");
+    if (!container || !dataEl) return;
+    var svg = container.querySelector("svg");
+    var data = JSON.parse(dataEl.textContent);
+    if (!svg || !data.runs.length) return;
+
+    var tip = document.createElement("div");
+    tip.style.cssText =
+        "position:absolute;pointer-events:none;display:none;background:rgba(255,255,255,0.96);" +
+        "border:1px solid #999;border-radius:4px;padding:6px 8px;font:12px sans-serif;" +
+        "box-shadow:0 1px 4px rgba(0,0,0,0.25);z-index:10;max-width:340px";
+    container.appendChild(tip);
+
+    var guide = document.createElementNS("http://www.w3.org/2000/svg", "line");
+    guide.setAttribute("stroke", "#888");
+    guide.setAttribute("stroke-dasharray", "3,3");
+    guide.setAttribute("y1", data.plot[1]);
+    guide.setAttribute("y2", data.plot[1] + data.plot[3]);
+    guide.style.display = "none";
+    svg.appendChild(guide);
+
+    function esc(s) {
+        return s.replace(/&/g, "&amp;").replace(/</g, "&lt;");
+    }
+
+    function nearest(x) {
+        var runs = data.runs, lo = 0, hi = runs.length - 1;
+        while (lo < hi) {
+            var mid = (lo + hi) >> 1;
+            if (runs[mid].x < x) lo = mid + 1; else hi = mid;
+        }
+        if (lo > 0 && Math.abs(runs[lo - 1].x - x) < Math.abs(runs[lo].x - x)) lo--;
+        return lo;
+    }
+
+    function hide() {
+        tip.style.display = "none";
+        guide.style.display = "none";
+    }
+
+    svg.addEventListener("mousemove", function (ev) {
+        var rect = svg.getBoundingClientRect();
+        var scale = data.width / rect.width;
+        var vx = (ev.clientX - rect.left) * scale;
+        var px = data.plot[0], pw = data.plot[2];
+        if (vx < px || vx > px + pw) { hide(); return; }
+
+        var xRange = data.xMax - data.xMin;
+        var run = data.runs[nearest(data.xMin + ((vx - px) / pw) * xRange)];
+        var runVx = px + ((run.x - data.xMin) / xRange) * pw;
+        guide.setAttribute("x1", runVx);
+        guide.setAttribute("x2", runVx);
+        guide.style.display = "";
+
+        var html = "<div style='font-weight:bold'>" + esc(run.sha.slice(0, 9)) + " (" + esc(run.d) + ")</div>";
+        if (run.msg) html += "<div style='margin-bottom:4px'>" + esc(run.msg) + "</div>";
+        for (var i = 0; i < data.series.length; i++) {
+            if (run.v[i] == null) continue;
+            html += "<div><span style='color:" + data.series[i].color + "'>\u25CF</span> " +
+                esc(data.series[i].name) + ": " + run.v[i].toFixed(1) + "%</div>";
+        }
+        tip.innerHTML = html;
+        tip.style.display = "block";
+
+        var crect = container.getBoundingClientRect();
+        var cx = ev.clientX - crect.left, cy = ev.clientY - crect.top;
+        var left = cx + 14;
+        if (left + tip.offsetWidth > container.clientWidth) left = cx - tip.offsetWidth - 14;
+        tip.style.left = left + "px";
+        tip.style.top = (cy + 14) + "px";
+    });
+    svg.addEventListener("mouseleave", hide);
+})();
+"##;
+
 #[component]
-pub fn WptHistoryChart(summary: ArcWptSummary, range: ChartRange) -> Element {
+pub fn WptHistoryChart(
+    summary: ArcWptSummary,
+    range: ChartRange,
+    commit_messages: ArcCommitMessages,
+) -> Element {
     const WIDTH: f64 = 900.0;
     const HEIGHT: f64 = 440.0;
     const PLOT: (f64, f64, f64, f64) = (50.0, 15.0, WIDTH - 65.0, HEIGHT - 55.0);
@@ -319,7 +422,59 @@ pub fn WptHistoryChart(summary: ArcWptSummary, range: ChartRange) -> Element {
     let ticks = month_ticks(x_min, x_max);
     let x_range = (x_max - x_min).max(f64::EPSILON);
 
+    // Per-run data for the hover tooltip (a JS progressive enhancement)
+    let area_indices: Vec<Option<usize>> = HIGHLIGHT_AREAS
+        .iter()
+        .map(|(area, _)| summary.focus_areas.iter().position(|a| a == area))
+        .collect();
+    let runs_json: Vec<serde_json::Value> = summary
+        .runs
+        .iter()
+        .filter_map(|run| {
+            let x = parse_date(&run.date)?;
+            if x < min_x {
+                return None;
+            }
+            let values: Vec<serde_json::Value> = area_indices
+                .iter()
+                .map(|idx| {
+                    idx.and_then(|idx| subtest_pass_percent(run, idx))
+                        .map(|pct| serde_json::json!((pct * 10.0).round() / 10.0))
+                        .unwrap_or(serde_json::Value::Null)
+                })
+                .collect();
+            Some(serde_json::json!({
+                "x": x,
+                "d": run.date.split('T').next().unwrap_or(&run.date),
+                "sha": run.product_revision,
+                "msg": commit_messages.get(&run.product_revision),
+                "v": values,
+            }))
+        })
+        .collect();
+    let tooltip_data = serde_json::json!({
+        "width": WIDTH,
+        "plot": [px, py, pw, ph],
+        "xMin": x_min,
+        "xMax": x_max,
+        "series": series
+            .iter()
+            .map(|s| serde_json::json!({
+                "name": s.name.strip_prefix("css/").unwrap_or("all css"),
+                "color": s.color,
+            }))
+            .collect::<Vec<_>>(),
+        "runs": runs_json,
+    })
+    .to_string()
+    // Prevent "</script>" in commit messages from terminating the data block
+    .replace('<', "\\u003c");
+
     rsx! {
+        div {
+            id: "wpt-history-chart",
+            position: "relative",
+
         svg {
             view_box: "0 0 {WIDTH} {HEIGHT}",
             width: "100%",
@@ -393,6 +548,14 @@ pub fn WptHistoryChart(summary: ArcWptSummary, range: ChartRange) -> Element {
                     {s.name.strip_prefix("css/").unwrap_or("all css")}
                 }
             }
+        }
+
+        script {
+            id: "wpt-history-data",
+            r#type: "application/json",
+            dangerous_inner_html: tooltip_data,
+        }
+        script { dangerous_inner_html: TOOLTIP_JS }
         }
     }
 }

--- a/src/routes/wpt_history.rs
+++ b/src/routes/wpt_history.rs
@@ -409,8 +409,8 @@ const TOOLTIP_JS: &str = r##"
             var dPct = 100 * (pass / total - prev.v[best][0] / prev.v[best][1]);
             var sign = dPass > 0 ? "+" : "";
             var color = dPass > 0 ? "#2e7d32" : (dPass < 0 ? "#c62828" : "#666");
-            html += "<div style='color:" + color + "'>\u0394 vs prev: " + sign +
-                dPass.toLocaleString() + " (" + sign + dPct.toFixed(2) + "pp)</div>";
+            html += "<div style='color:" + color + "'>Change: " + sign +
+                dPass.toLocaleString() + " (" + sign + dPct.toFixed(2) + "%)</div>";
         }
         tip.innerHTML = html;
         tip.style.display = "block";

--- a/src/routes/wpt_history.rs
+++ b/src/routes/wpt_history.rs
@@ -75,19 +75,6 @@ struct Series {
     points: Vec<(f64, f64)>,
 }
 
-/// Runs before this date are excluded from the charts: WPT runs for the
-/// entire prior commit history of Blitz were bulk-executed on 2026-04-13/14,
-/// so those runs' dates don't reflect real progress over time and include a
-/// number of broken runs.
-const CHART_START_DATE: &str = "2026-04-15";
-
-fn chart_runs(summary: &ScoreSummaryReport) -> impl Iterator<Item = &RunSummary> {
-    summary
-        .runs
-        .iter()
-        .filter(|run| run.date.as_str() >= CHART_START_DATE)
-}
-
 fn subtest_pass_percent(run: &RunSummary, area_idx: usize) -> Option<f64> {
     let scores = run.scores.get(area_idx)?;
     if scores.total_subtests == 0 {
@@ -102,7 +89,9 @@ fn area_series(
     color: &'static str,
 ) -> Option<Series> {
     let area_idx = summary.focus_areas.iter().position(|a| a == area)?;
-    let points: Vec<(f64, f64)> = chart_runs(summary)
+    let points: Vec<(f64, f64)> = summary
+        .runs
+        .iter()
         .filter_map(|run| Some((parse_date(&run.date)?, subtest_pass_percent(run, area_idx)?)))
         .collect();
     if points.is_empty() {
@@ -317,11 +306,13 @@ pub fn WptHistorySparklines(summary: ArcWptSummary) -> Element {
     const HEIGHT: f64 = 60.0;
     const PLOT: (f64, f64, f64, f64) = (0.0, 2.0, WIDTH, HEIGHT - 4.0);
 
-    let x_min = chart_runs(&summary)
-        .next()
+    let x_min = summary
+        .runs
+        .first()
         .and_then(|run| parse_date(&run.date))
         .unwrap_or(0.0);
-    let x_max = chart_runs(&summary)
+    let x_max = summary
+        .runs
         .last()
         .and_then(|run| parse_date(&run.date))
         .unwrap_or(1.0);
@@ -334,7 +325,9 @@ pub fn WptHistorySparklines(summary: ArcWptSummary) -> Element {
 
             for (area_idx, area) in summary.focus_areas.iter().enumerate() {
                 {
-                    let points: Vec<(f64, f64)> = chart_runs(&summary)
+                    let points: Vec<(f64, f64)> = summary
+                        .runs
+                        .iter()
                         .filter_map(|run| {
                             Some((parse_date(&run.date)?, subtest_pass_percent(run, area_idx)?))
                         })

--- a/src/routes/wpt_history.rs
+++ b/src/routes/wpt_history.rs
@@ -457,11 +457,11 @@ pub fn WptHistoryChart(
     history: ArcWptHistory,
     series_spec: Vec<ChartSeries>,
     range: ChartRange,
+    #[props(default = 440.0)] height: f64,
 ) -> Element {
     const WIDTH: f64 = 900.0;
-    const HEIGHT: f64 = 440.0;
-    const PLOT: (f64, f64, f64, f64) = (50.0, 15.0, WIDTH - 65.0, HEIGHT - 55.0);
-    let (px, py, pw, ph) = PLOT;
+    let plot: (f64, f64, f64, f64) = (50.0, 15.0, WIDTH - 65.0, height - 55.0);
+    let (px, py, pw, ph) = plot;
 
     let min_x = range.min_x(&history);
     let series: Vec<Series> = series_spec
@@ -543,11 +543,12 @@ pub fn WptHistoryChart(
             position: "relative",
 
         svg {
-            view_box: "0 0 {WIDTH} {HEIGHT}",
+            view_box: "0 0 {WIDTH} {height}",
             width: "100%",
             font_family: "sans-serif",
 
-            // Horizontal gridlines + y-axis labels (every 10%)
+            // Horizontal gridlines + y-axis labels (every 10%; label every
+            // 20% when the chart is short)
             for i in 0..=10u32 {
                 line {
                     x1: "{px}",
@@ -557,13 +558,15 @@ pub fn WptHistoryChart(
                     stroke: if i % 5 == 0 { "#bbb" } else { "#e5e5e5" },
                     stroke_width: "1",
                 }
-                text {
-                    x: "{px - 6.0}",
-                    y: "{py + ph * (1.0 - (i as f64) / 10.0) + 4.0}",
-                    text_anchor: "end",
-                    font_size: "12",
-                    fill: "#666",
-                    "{i * 10}%"
+                if ph >= 300.0 || i % 2 == 0 {
+                    text {
+                        x: "{px - 6.0}",
+                        y: "{py + ph * (1.0 - (i as f64) / 10.0) + 4.0}",
+                        text_anchor: "end",
+                        font_size: "12",
+                        fill: "#666",
+                        "{i * 10}%"
+                    }
                 }
             }
 
@@ -590,7 +593,7 @@ pub fn WptHistoryChart(
             // Data series
             for (i, s) in series.iter().enumerate() {
                 polyline {
-                    points: polyline_points(&s.points, x_min, x_max, PLOT),
+                    points: polyline_points(&s.points, x_min, x_max, plot),
                     fill: "none",
                     stroke: s.color,
                     stroke_width: if i == 0 { "2.5" } else { "1.5" },
@@ -602,14 +605,14 @@ pub fn WptHistoryChart(
                 line {
                     x1: "{px + 10.0 + (i as f64) * 140.0}",
                     x2: "{px + 34.0 + (i as f64) * 140.0}",
-                    y1: "{HEIGHT - 10.0}",
-                    y2: "{HEIGHT - 10.0}",
+                    y1: "{height - 10.0}",
+                    y2: "{height - 10.0}",
                     stroke: s.color,
                     stroke_width: "3",
                 }
                 text {
                     x: "{px + 40.0 + (i as f64) * 140.0}",
-                    y: "{HEIGHT - 6.0}",
+                    y: "{height - 6.0}",
                     font_size: "12",
                     fill: "#333",
                     {s.label.clone()}

--- a/src/routes/wpt_history.rs
+++ b/src/routes/wpt_history.rs
@@ -159,20 +159,39 @@ struct Series {
     points: Vec<(f64, f64)>,
 }
 
-fn subtest_pass_percent(run: &HistoryRun, area_idx: usize) -> Option<f64> {
+/// The subtest total of the most recent run with data for this area.
+/// Percentages are computed against this so that adding tests to WPT does
+/// not distort historical pass rates.
+fn latest_subtest_total(history: &WptHistory, area_idx: usize) -> Option<u32> {
+    history
+        .runs
+        .iter()
+        .rev()
+        .filter_map(|run| *run.scores.get(area_idx)?)
+        .map(|(_, _, total_subtests, _)| total_subtests)
+        .find(|total| *total != 0)
+}
+
+fn subtest_pass_percent(run: &HistoryRun, area_idx: usize, latest_total: u32) -> Option<f64> {
     let (_, _, total_subtests, total_subtests_passed) = (*run.scores.get(area_idx)?)?;
     if total_subtests == 0 {
         return None;
     }
-    Some(total_subtests_passed as f64 / total_subtests as f64 * 100.0)
+    Some(total_subtests_passed as f64 / latest_total as f64 * 100.0)
 }
 
 fn area_series(history: &WptHistory, min_x: f64, spec: &ChartSeries) -> Option<Series> {
     let area_idx = history.focus_areas.iter().position(|a| *a == spec.area)?;
+    let latest_total = latest_subtest_total(history, area_idx)?;
     let points: Vec<(f64, f64)> = history
         .runs
         .iter()
-        .filter_map(|run| Some((parse_date(&run.date)?, subtest_pass_percent(run, area_idx)?)))
+        .filter_map(|run| {
+            Some((
+                parse_date(&run.date)?,
+                subtest_pass_percent(run, area_idx, latest_total)?,
+            ))
+        })
         .filter(|(x, _)| *x >= min_x)
         .collect();
     if points.is_empty() {
@@ -364,6 +383,12 @@ pub fn WptHistoryChart(
         .iter()
         .map(|spec| history.focus_areas.iter().position(|a| *a == spec.area))
         .collect();
+    // Latest subtest total per series: the denominator for plotted
+    // percentages (must match `area_series`)
+    let latest_totals: Vec<Option<u32>> = area_indices
+        .iter()
+        .map(|idx| latest_subtest_total(&history, (*idx)?))
+        .collect();
     // Include the run immediately before the visible range (if any) so the
     // first visible run's tooltip can show a delta against it
     let first_visible = history
@@ -402,9 +427,10 @@ pub fn WptHistoryChart(
         "plot": [px, py, pw, ph],
         "xMin": x_min,
         "xMax": x_max,
-        "series": series
+        "series": series_spec
             .iter()
-            .map(|s| serde_json::json!({ "name": s.label, "color": s.color }))
+            .zip(&latest_totals)
+            .map(|(s, latest)| serde_json::json!({ "name": s.label, "color": s.color, "latest": latest }))
             .collect::<Vec<_>>(),
         "runs": runs_json,
     })
@@ -531,11 +557,15 @@ pub fn WptHistorySparklines(history: ArcWptHistory, range: ChartRange) -> Elemen
 
             for (area_idx, area) in history.focus_areas.iter().enumerate() {
                 {
+                    let latest_total = latest_subtest_total(&history, area_idx);
                     let points: Vec<(f64, f64)> = history
                         .runs
                         .iter()
                         .filter_map(|run| {
-                            Some((parse_date(&run.date)?, subtest_pass_percent(run, area_idx)?))
+                            Some((
+                                parse_date(&run.date)?,
+                                subtest_pass_percent(run, area_idx, latest_total?)?,
+                            ))
                         })
                         .filter(|(x, _)| *x >= range_min_x)
                         .collect();

--- a/src/routes/wpt_history.rs
+++ b/src/routes/wpt_history.rs
@@ -1,34 +1,20 @@
 use std::{fmt::Write, ops::Deref, sync::Arc};
 
 use dioxus::prelude::*;
-use wptreport::score_summary::{RunSummary, ScoreSummaryReport};
 
-use crate::routes::{StatusHeader, StatusTabs};
 use crate::components::Page;
+use crate::routes::{StatusHeader, StatusTabs};
+use crate::wpt_history::{HistoryRun, WptHistory};
 
 #[derive(Clone)]
-pub struct ArcCommitMessages(pub Arc<std::collections::HashMap<String, String>>);
-impl PartialEq for ArcCommitMessages {
+pub struct ArcWptHistory(pub Arc<WptHistory>);
+impl PartialEq for ArcWptHistory {
     fn eq(&self, other: &Self) -> bool {
         Arc::ptr_eq(&self.0, &other.0)
     }
 }
-impl Deref for ArcCommitMessages {
-    type Target = std::collections::HashMap<String, String>;
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-#[derive(Clone)]
-pub struct ArcWptSummary(pub Arc<ScoreSummaryReport>);
-impl PartialEq for ArcWptSummary {
-    fn eq(&self, other: &Self) -> bool {
-        Arc::ptr_eq(&self.0, &other.0)
-    }
-}
-impl Deref for ArcWptSummary {
-    type Target = ScoreSummaryReport;
+impl Deref for ArcWptHistory {
+    type Target = WptHistory;
     fn deref(&self) -> &Self::Target {
         &self.0
     }
@@ -144,8 +130,8 @@ impl ChartRange {
 
     /// The earliest date (in fractional epoch-days) included in the range,
     /// measured back from the date of the latest run
-    fn min_x(self, summary: &ScoreSummaryReport) -> f64 {
-        let latest = summary
+    fn min_x(self, history: &WptHistory) -> f64 {
+        let latest = history
             .runs
             .last()
             .and_then(|run| parse_date(&run.date))
@@ -157,28 +143,33 @@ impl ChartRange {
     }
 }
 
+/// A single line on the history chart
+#[derive(Clone, PartialEq)]
+pub struct ChartSeries {
+    /// The focus area charted (e.g. "css/css-flexbox")
+    pub area: String,
+    /// The label shown in the legend and tooltip
+    pub label: String,
+    pub color: &'static str,
+}
+
 struct Series {
-    name: &'static str,
+    label: String,
     color: &'static str,
     points: Vec<(f64, f64)>,
 }
 
-fn subtest_pass_percent(run: &RunSummary, area_idx: usize) -> Option<f64> {
-    let scores = run.scores.get(area_idx)?;
-    if scores.total_subtests == 0 {
+fn subtest_pass_percent(run: &HistoryRun, area_idx: usize) -> Option<f64> {
+    let (_, _, total_subtests, total_subtests_passed) = (*run.scores.get(area_idx)?)?;
+    if total_subtests == 0 {
         return None;
     }
-    Some(scores.total_subtests_passed as f64 / scores.total_subtests as f64 * 100.0)
+    Some(total_subtests_passed as f64 / total_subtests as f64 * 100.0)
 }
 
-fn area_series(
-    summary: &ScoreSummaryReport,
-    min_x: f64,
-    area: &'static str,
-    color: &'static str,
-) -> Option<Series> {
-    let area_idx = summary.focus_areas.iter().position(|a| a == area)?;
-    let points: Vec<(f64, f64)> = summary
+fn area_series(history: &WptHistory, min_x: f64, spec: &ChartSeries) -> Option<Series> {
+    let area_idx = history.focus_areas.iter().position(|a| *a == spec.area)?;
+    let points: Vec<(f64, f64)> = history
         .runs
         .iter()
         .filter_map(|run| Some((parse_date(&run.date)?, subtest_pass_percent(run, area_idx)?)))
@@ -188,8 +179,8 @@ fn area_series(
         return None;
     }
     Some(Series {
-        name: area,
-        color,
+        label: spec.label.clone(),
+        color: spec.color,
         points,
     })
 }
@@ -257,11 +248,7 @@ fn month_ticks(x_min: f64, x_max: f64) -> Vec<(f64, String)> {
 }
 
 #[component]
-pub fn WptHistoryPage(
-    summary: ArcWptSummary,
-    range: ChartRange,
-    commit_messages: ArcCommitMessages,
-) -> Element {
+pub fn WptHistoryPage(history: ArcWptHistory, range: ChartRange) -> Element {
     rsx! {
         Page { title: "Status: WPT History".into(),
             StatusHeader {}
@@ -272,16 +259,20 @@ pub fn WptHistoryPage(
                 Scores are the percentage of subtests passing (of those that Blitz can run). Data is recorded for every commit to the main branch."#
             }
             hr {}
-            ChartRangeSelector { current_range: range }
-            WptHistoryChart { summary: summary.clone(), range, commit_messages }
+            ChartRangeSelector { current_range: range, base_path: "/status/wpt/history" }
+            WptHistoryChart {
+                history: history.clone(),
+                series_spec: highlight_series(),
+                range,
+            }
             h2 { "Per-area history" }
-            WptHistorySparklines { summary, range }
+            WptHistorySparklines { history, range }
         }
     }
 }
 
 #[component]
-pub fn ChartRangeSelector(current_range: ChartRange) -> Element {
+pub fn ChartRangeSelector(current_range: ChartRange, base_path: String) -> Element {
     rsx! {
         div {
             display: "flex",
@@ -292,7 +283,7 @@ pub fn ChartRangeSelector(current_range: ChartRange) -> Element {
 
             for range in ChartRange::ALL {
                 a {
-                    href: "/status/wpt/history?range={range.query_value()}",
+                    href: "{base_path}?range={range.query_value()}",
                     padding: "2px 10px",
                     border_radius: "12px",
                     text_decoration: "none",
@@ -305,23 +296,45 @@ pub fn ChartRangeSelector(current_range: ChartRange) -> Element {
     }
 }
 
-const HIGHLIGHT_AREAS: &[(&str, &str)] = &[
-    ("css", "#000000"),
-    ("css/CSS2", "#e57373"),
-    ("css/css-flexbox", "#7986cb"),
-    ("css/css-grid", "#4db6ac"),
-    ("css/css-text", "#ffb74d"),
-    ("css/css-position", "#ba68c8"),
+/// Colors assigned to chart lines, in order. The first is reserved for the
+/// "whole folder" line.
+pub const SERIES_COLORS: &[&str] = &[
+    "#000000", "#e57373", "#7986cb", "#4db6ac", "#ffb74d", "#ba68c8", "#64b5f6", "#a1887f",
 ];
 
+const HIGHLIGHT_AREAS: &[&str] = &[
+    "css",
+    "css/CSS2",
+    "css/css-flexbox",
+    "css/css-grid",
+    "css/css-text",
+    "css/css-position",
+];
+
+fn highlight_series() -> Vec<ChartSeries> {
+    HIGHLIGHT_AREAS
+        .iter()
+        .zip(SERIES_COLORS)
+        .map(|(area, color)| ChartSeries {
+            area: area.to_string(),
+            label: area
+                .strip_prefix("css/")
+                .unwrap_or("all css")
+                .to_string(),
+            color,
+        })
+        .collect()
+}
+
 /// Inline script implementing the hover tooltip as a progressive enhancement.
-/// Reads run data from the `#wpt-history-data` JSON blob and shows the nearest
-/// run's commit id, commit message, and per-area pass percentages.
+/// Reads run data from the chart's JSON blob and shows the nearest run's
+/// commit id, commit message, and pass percentages for the nearest line.
 const TOOLTIP_JS: &str = r##"
 (function () {
-    var container = document.getElementById("wpt-history-chart");
-    var dataEl = document.getElementById("wpt-history-data");
-    if (!container || !dataEl) return;
+    var scripts = document.querySelectorAll("script[data-wpt-history-data]");
+    var dataEl = scripts[scripts.length - 1];
+    if (!dataEl) return;
+    var container = dataEl.parentElement;
     var svg = container.querySelector("svg");
     var data = JSON.parse(dataEl.textContent);
     if (!svg || !data.runs.length) return;
@@ -441,19 +454,19 @@ const TOOLTIP_JS: &str = r##"
 
 #[component]
 pub fn WptHistoryChart(
-    summary: ArcWptSummary,
+    history: ArcWptHistory,
+    series_spec: Vec<ChartSeries>,
     range: ChartRange,
-    commit_messages: ArcCommitMessages,
 ) -> Element {
     const WIDTH: f64 = 900.0;
     const HEIGHT: f64 = 440.0;
     const PLOT: (f64, f64, f64, f64) = (50.0, 15.0, WIDTH - 65.0, HEIGHT - 55.0);
     let (px, py, pw, ph) = PLOT;
 
-    let min_x = range.min_x(&summary);
-    let series: Vec<Series> = HIGHLIGHT_AREAS
+    let min_x = range.min_x(&history);
+    let series: Vec<Series> = series_spec
         .iter()
-        .filter_map(|(area, color)| area_series(&summary, min_x, area, color))
+        .filter_map(|spec| area_series(&history, min_x, spec))
         .collect();
 
     let x_min = series
@@ -473,32 +486,29 @@ pub fn WptHistoryChart(
     let x_range = (x_max - x_min).max(f64::EPSILON);
 
     // Per-run data for the hover tooltip (a JS progressive enhancement)
-    let area_indices: Vec<Option<usize>> = HIGHLIGHT_AREAS
+    let area_indices: Vec<Option<usize>> = series_spec
         .iter()
-        .map(|(area, _)| summary.focus_areas.iter().position(|a| a == area))
+        .map(|spec| history.focus_areas.iter().position(|a| *a == spec.area))
         .collect();
     // Include the run immediately before the visible range (if any) so the
     // first visible run's tooltip can show a delta against it
-    let first_visible = summary
+    let first_visible = history
         .runs
         .iter()
         .position(|run| parse_date(&run.date).is_some_and(|x| x >= min_x))
         .unwrap_or(0);
     let start = first_visible.saturating_sub(1);
-    let runs_json: Vec<serde_json::Value> = summary.runs[start..]
+    let runs_json: Vec<serde_json::Value> = history.runs[start..]
         .iter()
         .filter_map(|run| {
             let x = parse_date(&run.date)?;
             let values: Vec<serde_json::Value> = area_indices
                 .iter()
                 .map(|idx| {
-                    idx.and_then(|idx| run.scores.get(idx))
-                        .filter(|scores| scores.total_subtests != 0)
-                        .map(|scores| {
-                            serde_json::json!([
-                                scores.total_subtests_passed,
-                                scores.total_subtests
-                            ])
+                    idx.and_then(|idx| *run.scores.get(idx)?)
+                        .filter(|(_, _, total_subtests, _)| *total_subtests != 0)
+                        .map(|(_, _, total_subtests, total_subtests_passed)| {
+                            serde_json::json!([total_subtests_passed, total_subtests])
                         })
                         .unwrap_or(serde_json::Value::Null)
                 })
@@ -507,7 +517,7 @@ pub fn WptHistoryChart(
                 "x": x,
                 "d": run.date.split('T').next().unwrap_or(&run.date),
                 "sha": run.product_revision,
-                "msg": commit_messages.get(&run.product_revision),
+                "msg": run.commit_message,
                 "v": values,
             }))
         })
@@ -520,10 +530,7 @@ pub fn WptHistoryChart(
         "xMax": x_max,
         "series": series
             .iter()
-            .map(|s| serde_json::json!({
-                "name": s.name.strip_prefix("css/").unwrap_or("all css"),
-                "color": s.color,
-            }))
+            .map(|s| serde_json::json!({ "name": s.label, "color": s.color }))
             .collect::<Vec<_>>(),
         "runs": runs_json,
     })
@@ -533,7 +540,6 @@ pub fn WptHistoryChart(
 
     rsx! {
         div {
-            id: "wpt-history-chart",
             position: "relative",
 
         svg {
@@ -582,12 +588,12 @@ pub fn WptHistoryChart(
             }
 
             // Data series
-            for s in series.iter() {
+            for (i, s) in series.iter().enumerate() {
                 polyline {
                     points: polyline_points(&s.points, x_min, x_max, PLOT),
                     fill: "none",
                     stroke: s.color,
-                    stroke_width: if s.name == "css" { "2.5" } else { "1.5" },
+                    stroke_width: if i == 0 { "2.5" } else { "1.5" },
                 }
             }
 
@@ -606,13 +612,13 @@ pub fn WptHistoryChart(
                     y: "{HEIGHT - 6.0}",
                     font_size: "12",
                     fill: "#333",
-                    {s.name.strip_prefix("css/").unwrap_or("all css")}
+                    {s.label.clone()}
                 }
             }
         }
 
         script {
-            id: "wpt-history-data",
+            "data-wpt-history-data": "true",
             r#type: "application/json",
             dangerous_inner_html: tooltip_data,
         }
@@ -622,19 +628,19 @@ pub fn WptHistoryChart(
 }
 
 #[component]
-pub fn WptHistorySparklines(summary: ArcWptSummary, range: ChartRange) -> Element {
+pub fn WptHistorySparklines(history: ArcWptHistory, range: ChartRange) -> Element {
     const WIDTH: f64 = 260.0;
     const HEIGHT: f64 = 60.0;
     const PLOT: (f64, f64, f64, f64) = (0.0, 2.0, WIDTH, HEIGHT - 4.0);
 
-    let range_min_x = range.min_x(&summary);
-    let x_min = summary
+    let range_min_x = range.min_x(&history);
+    let x_min = history
         .runs
         .first()
         .and_then(|run| parse_date(&run.date))
         .unwrap_or(0.0)
         .max(range_min_x);
-    let x_max = summary
+    let x_max = history
         .runs
         .last()
         .and_then(|run| parse_date(&run.date))
@@ -646,9 +652,9 @@ pub fn WptHistorySparklines(summary: ArcWptSummary, range: ChartRange) -> Elemen
             grid_template_columns: "repeat(auto-fill, minmax(280px, 1fr))",
             gap: "16px",
 
-            for (area_idx, area) in summary.focus_areas.iter().enumerate() {
+            for (area_idx, area) in history.focus_areas.iter().enumerate() {
                 {
-                    let points: Vec<(f64, f64)> = summary
+                    let points: Vec<(f64, f64)> = history
                         .runs
                         .iter()
                         .filter_map(|run| {

--- a/src/routes/wpt_history.rs
+++ b/src/routes/wpt_history.rs
@@ -341,6 +341,13 @@ const TOOLTIP_JS: &str = r##"
     guide.style.display = "none";
     svg.appendChild(guide);
 
+    var dot = document.createElementNS("http://www.w3.org/2000/svg", "circle");
+    dot.setAttribute("r", 4);
+    dot.setAttribute("stroke", "white");
+    dot.setAttribute("stroke-width", 1.5);
+    dot.style.display = "none";
+    svg.appendChild(dot);
+
     function esc(s) {
         return s.replace(/&/g, "&amp;").replace(/</g, "&lt;");
     }
@@ -359,6 +366,7 @@ const TOOLTIP_JS: &str = r##"
     function hide() {
         tip.style.display = "none";
         guide.style.display = "none";
+        dot.style.display = "none";
     }
 
     // Only show the series whose line is within this vertical distance
@@ -392,6 +400,11 @@ const TOOLTIP_JS: &str = r##"
         guide.setAttribute("x1", runVx);
         guide.setAttribute("x2", runVx);
         guide.style.display = "";
+
+        dot.setAttribute("cx", runVx);
+        dot.setAttribute("cy", py + (1 - (run.v[best][0] / run.v[best][1])) * ph);
+        dot.setAttribute("fill", data.series[best].color);
+        dot.style.display = "";
 
         var html = "<div style='font-weight:bold'>" + esc(run.sha.slice(0, 9)) + " (" + esc(run.d) + ")</div>";
         if (run.msg) {

--- a/src/routes/wpt_history.rs
+++ b/src/routes/wpt_history.rs
@@ -321,14 +321,7 @@ pub const SERIES_COLORS: &[&str] = &[
     "#000000", "#e57373", "#7986cb", "#4db6ac", "#ffb74d", "#ba68c8", "#64b5f6", "#a1887f",
 ];
 
-const HIGHLIGHT_AREAS: &[&str] = &[
-    "css",
-    "css/CSS2",
-    "css/css-flexbox",
-    "css/css-grid",
-    "css/css-text",
-    "css/css-position",
-];
+const HIGHLIGHT_AREAS: &[&str] = &["css", "css/CSS2"];
 
 fn highlight_series() -> Vec<ChartSeries> {
     HIGHLIGHT_AREAS

--- a/src/routes/wpt_history.rs
+++ b/src/routes/wpt_history.rs
@@ -69,6 +69,74 @@ const MONTH_NAMES: [&str; 12] = [
     "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
 ];
 
+#[derive(Copy, Clone, PartialEq, Debug, Default)]
+pub enum ChartRange {
+    Months3,
+    Months6,
+    Year1,
+    #[default]
+    All,
+}
+
+impl ChartRange {
+    pub const ALL: [ChartRange; 4] = [
+        ChartRange::Months3,
+        ChartRange::Months6,
+        ChartRange::Year1,
+        ChartRange::All,
+    ];
+
+    pub fn from_query(value: Option<&str>) -> Self {
+        match value {
+            Some("3m") => ChartRange::Months3,
+            Some("6m") => ChartRange::Months6,
+            Some("1y") => ChartRange::Year1,
+            _ => ChartRange::All,
+        }
+    }
+
+    fn query_value(self) -> &'static str {
+        match self {
+            ChartRange::Months3 => "3m",
+            ChartRange::Months6 => "6m",
+            ChartRange::Year1 => "1y",
+            ChartRange::All => "all",
+        }
+    }
+
+    fn label(self) -> &'static str {
+        match self {
+            ChartRange::Months3 => "3 months",
+            ChartRange::Months6 => "6 months",
+            ChartRange::Year1 => "1 year",
+            ChartRange::All => "All time",
+        }
+    }
+
+    fn days(self) -> Option<f64> {
+        match self {
+            ChartRange::Months3 => Some(91.0),
+            ChartRange::Months6 => Some(183.0),
+            ChartRange::Year1 => Some(365.0),
+            ChartRange::All => None,
+        }
+    }
+
+    /// The earliest date (in fractional epoch-days) included in the range,
+    /// measured back from the date of the latest run
+    fn min_x(self, summary: &ScoreSummaryReport) -> f64 {
+        let latest = summary
+            .runs
+            .last()
+            .and_then(|run| parse_date(&run.date))
+            .unwrap_or(0.0);
+        match self.days() {
+            Some(days) => latest - days,
+            None => f64::NEG_INFINITY,
+        }
+    }
+}
+
 struct Series {
     name: &'static str,
     color: &'static str,
@@ -85,6 +153,7 @@ fn subtest_pass_percent(run: &RunSummary, area_idx: usize) -> Option<f64> {
 
 fn area_series(
     summary: &ScoreSummaryReport,
+    min_x: f64,
     area: &'static str,
     color: &'static str,
 ) -> Option<Series> {
@@ -93,6 +162,7 @@ fn area_series(
         .runs
         .iter()
         .filter_map(|run| Some((parse_date(&run.date)?, subtest_pass_percent(run, area_idx)?)))
+        .filter(|(x, _)| *x >= min_x)
         .collect();
     if points.is_empty() {
         return None;
@@ -167,7 +237,7 @@ fn month_ticks(x_min: f64, x_max: f64) -> Vec<(f64, String)> {
 }
 
 #[component]
-pub fn WptHistoryPage(summary: ArcWptSummary) -> Element {
+pub fn WptHistoryPage(summary: ArcWptSummary, range: ChartRange) -> Element {
     rsx! {
         Page { title: "Status: WPT History".into(),
             StatusHeader {}
@@ -178,9 +248,35 @@ pub fn WptHistoryPage(summary: ArcWptSummary) -> Element {
                 Scores are the percentage of subtests passing (of those that Blitz can run). Data is recorded for every commit to the main branch."#
             }
             hr {}
-            WptHistoryChart { summary: summary.clone() }
+            ChartRangeSelector { current_range: range }
+            WptHistoryChart { summary: summary.clone(), range }
             h2 { "Per-area history" }
-            WptHistorySparklines { summary }
+            WptHistorySparklines { summary, range }
+        }
+    }
+}
+
+#[component]
+pub fn ChartRangeSelector(current_range: ChartRange) -> Element {
+    rsx! {
+        div {
+            display: "flex",
+            gap: "8px",
+            justify_content: "flex-end",
+            font_size: "14px",
+            margin_bottom: "8px",
+
+            for range in ChartRange::ALL {
+                a {
+                    href: "/status/wpt/history?range={range.query_value()}",
+                    padding: "2px 10px",
+                    border_radius: "12px",
+                    text_decoration: "none",
+                    color: if range == current_range { "white" } else { "inherit" },
+                    background_color: if range == current_range { "#2b6e6c" } else { "#eee" },
+                    {range.label()}
+                }
+            }
         }
     }
 }
@@ -195,15 +291,16 @@ const HIGHLIGHT_AREAS: &[(&str, &str)] = &[
 ];
 
 #[component]
-pub fn WptHistoryChart(summary: ArcWptSummary) -> Element {
+pub fn WptHistoryChart(summary: ArcWptSummary, range: ChartRange) -> Element {
     const WIDTH: f64 = 900.0;
     const HEIGHT: f64 = 440.0;
     const PLOT: (f64, f64, f64, f64) = (50.0, 15.0, WIDTH - 65.0, HEIGHT - 55.0);
     let (px, py, pw, ph) = PLOT;
 
+    let min_x = range.min_x(&summary);
     let series: Vec<Series> = HIGHLIGHT_AREAS
         .iter()
-        .filter_map(|(area, color)| area_series(&summary, area, color))
+        .filter_map(|(area, color)| area_series(&summary, min_x, area, color))
         .collect();
 
     let x_min = series
@@ -301,16 +398,18 @@ pub fn WptHistoryChart(summary: ArcWptSummary) -> Element {
 }
 
 #[component]
-pub fn WptHistorySparklines(summary: ArcWptSummary) -> Element {
+pub fn WptHistorySparklines(summary: ArcWptSummary, range: ChartRange) -> Element {
     const WIDTH: f64 = 260.0;
     const HEIGHT: f64 = 60.0;
     const PLOT: (f64, f64, f64, f64) = (0.0, 2.0, WIDTH, HEIGHT - 4.0);
 
+    let range_min_x = range.min_x(&summary);
     let x_min = summary
         .runs
         .first()
         .and_then(|run| parse_date(&run.date))
-        .unwrap_or(0.0);
+        .unwrap_or(0.0)
+        .max(range_min_x);
     let x_max = summary
         .runs
         .last()
@@ -331,6 +430,7 @@ pub fn WptHistorySparklines(summary: ArcWptSummary) -> Element {
                         .filter_map(|run| {
                             Some((parse_date(&run.date)?, subtest_pass_percent(run, area_idx)?))
                         })
+                        .filter(|(x, _)| *x >= range_min_x)
                         .collect();
 
                     let latest = points.last().map(|p| p.1).unwrap_or(0.0);

--- a/src/routes/wpt_history.rs
+++ b/src/routes/wpt_history.rs
@@ -409,6 +409,27 @@ const TOOLTIP_JS: &str = r##"
         }
         if (best < 0) { hide(); return; }
 
+        // Prefer a nearby commit whose value actually changed for this
+        // series over the strictly-nearest commit
+        var SNAP_PX = 10;
+        function screenX(i) { return px + ((data.runs[i].x - data.xMin) / xRange) * pw; }
+        function hasChange(i) {
+            var cur = data.runs[i].v[best];
+            if (cur == null) return false;
+            var p = i > 0 ? data.runs[i - 1].v[best] : null;
+            return p == null || cur[0] !== p[0] || cur[1] !== p[1];
+        }
+        var snapped = -1, snappedDist = SNAP_PX;
+        for (var j = data.first; j < data.runs.length; j++) {
+            var d = Math.abs(screenX(j) - vx);
+            if (d <= snappedDist && hasChange(j)) { snapped = j; snappedDist = d; }
+        }
+        if (snapped >= 0 && !hasChange(runIdx)) {
+            runIdx = snapped;
+            run = data.runs[runIdx];
+            prev = runIdx > 0 ? data.runs[runIdx - 1] : null;
+        }
+
         var runVx = px + ((run.x - data.xMin) / xRange) * pw;
         guide.setAttribute("x1", runVx);
         guide.setAttribute("x2", runVx);

--- a/src/routes/wpt_history.rs
+++ b/src/routes/wpt_history.rs
@@ -375,8 +375,10 @@ const TOOLTIP_JS: &str = r##"
         }
         for (var i = 0; i < data.series.length; i++) {
             if (run.v[i] == null) continue;
+            var pass = run.v[i][0], total = run.v[i][1];
             html += "<div><span style='color:" + data.series[i].color + "'>\u25CF</span> " +
-                esc(data.series[i].name) + ": " + run.v[i].toFixed(1) + "%</div>";
+                esc(data.series[i].name) + ": " + (100 * pass / total).toFixed(1) + "% (" +
+                pass.toLocaleString() + "/" + total.toLocaleString() + ")</div>";
         }
         tip.innerHTML = html;
         tip.style.display = "block";
@@ -441,8 +443,14 @@ pub fn WptHistoryChart(
             let values: Vec<serde_json::Value> = area_indices
                 .iter()
                 .map(|idx| {
-                    idx.and_then(|idx| subtest_pass_percent(run, idx))
-                        .map(|pct| serde_json::json!((pct * 10.0).round() / 10.0))
+                    idx.and_then(|idx| run.scores.get(idx))
+                        .filter(|scores| scores.total_subtests != 0)
+                        .map(|scores| {
+                            serde_json::json!([
+                                scores.total_subtests_passed,
+                                scores.total_subtests
+                            ])
+                        })
                         .unwrap_or(serde_json::Value::Null)
                 })
                 .collect();

--- a/src/routes/wpt_history.rs
+++ b/src/routes/wpt_history.rs
@@ -1,0 +1,364 @@
+use std::{fmt::Write, ops::Deref, sync::Arc};
+
+use dioxus::prelude::*;
+use wptreport::score_summary::{RunSummary, ScoreSummaryReport};
+
+use crate::routes::{StatusHeader, StatusTabs};
+use crate::components::Page;
+
+#[derive(Clone)]
+pub struct ArcWptSummary(pub Arc<ScoreSummaryReport>);
+impl PartialEq for ArcWptSummary {
+    fn eq(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.0, &other.0)
+    }
+}
+impl Deref for ArcWptSummary {
+    type Target = ScoreSummaryReport;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+/// Days since 1970-01-01 for a year/month/day (Howard Hinnant's civil-days algorithm)
+fn days_from_civil(y: i64, m: i64, d: i64) -> i64 {
+    let y = if m <= 2 { y - 1 } else { y };
+    let era = if y >= 0 { y } else { y - 399 } / 400;
+    let yoe = y - era * 400;
+    let mp = (m + 9) % 12;
+    let doy = (153 * mp + 2) / 5 + d - 1;
+    let doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;
+    era * 146097 + doe - 719468
+}
+
+/// Parse a date of the form YYYY-MM-DD or YYYY-MM-DDTHH:MM:SSZ into fractional
+/// days since the unix epoch.
+fn parse_date(date: &str) -> Option<f64> {
+    let year: i64 = date.get(0..4)?.parse().ok()?;
+    let month: i64 = date.get(5..7)?.parse().ok()?;
+    let day: i64 = date.get(8..10)?.parse().ok()?;
+    let mut days = days_from_civil(year, month, day) as f64;
+
+    if let (Some(h), Some(m), Some(s)) = (date.get(11..13), date.get(14..16), date.get(17..19)) {
+        let (h, m, s): (f64, f64, f64) = (
+            h.parse().unwrap_or(0.0),
+            m.parse().unwrap_or(0.0),
+            s.parse().unwrap_or(0.0),
+        );
+        days += (h * 3600.0 + m * 60.0 + s) / 86400.0;
+    }
+
+    Some(days)
+}
+
+/// Convert fractional days since the unix epoch back into a (year, month) pair
+fn civil_from_days(z: i64) -> (i64, i64) {
+    let z = z + 719468;
+    let era = if z >= 0 { z } else { z - 146096 } / 146097;
+    let doe = z - era * 146097;
+    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146096) / 365;
+    let y = yoe + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let m = if mp < 10 { mp + 3 } else { mp - 9 };
+    let y = if m <= 2 { y + 1 } else { y };
+    (y, m)
+}
+
+const MONTH_NAMES: [&str; 12] = [
+    "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
+];
+
+struct Series {
+    name: &'static str,
+    color: &'static str,
+    points: Vec<(f64, f64)>,
+}
+
+fn subtest_pass_percent(run: &RunSummary, area_idx: usize) -> Option<f64> {
+    let scores = run.scores.get(area_idx)?;
+    if scores.total_subtests == 0 {
+        return None;
+    }
+    Some(scores.total_subtests_passed as f64 / scores.total_subtests as f64 * 100.0)
+}
+
+fn area_series(
+    summary: &ScoreSummaryReport,
+    area: &'static str,
+    color: &'static str,
+) -> Option<Series> {
+    let area_idx = summary.focus_areas.iter().position(|a| a == area)?;
+    let points: Vec<(f64, f64)> = summary
+        .runs
+        .iter()
+        .filter_map(|run| Some((parse_date(&run.date)?, subtest_pass_percent(run, area_idx)?)))
+        .collect();
+    if points.is_empty() {
+        return None;
+    }
+    Some(Series {
+        name: area,
+        color,
+        points,
+    })
+}
+
+fn polyline_points(
+    points: &[(f64, f64)],
+    x_min: f64,
+    x_max: f64,
+    plot: (f64, f64, f64, f64), // (x, y, width, height) of plot area
+) -> String {
+    if points.is_empty() {
+        return String::new();
+    }
+
+    let (px, py, pw, ph) = plot;
+    let x_range = (x_max - x_min).max(f64::EPSILON);
+
+    // Downsample long series to at most ~400 points to keep the SVG small
+    let stride = points.len().div_ceil(400).max(1);
+    let mut out = String::new();
+    let mut plot_point = |&(x, y): &(f64, f64)| {
+        let sx = px + (x - x_min) / x_range * pw;
+        let sy = py + (1.0 - y / 100.0) * ph;
+        write!(out, "{sx:.1},{sy:.1} ").unwrap();
+    };
+    for point in points.iter().step_by(stride) {
+        plot_point(point);
+    }
+    // Always include the final point so the latest result is shown
+    let last_plotted = (points.len() - 1) / stride * stride;
+    if last_plotted != points.len() - 1 {
+        plot_point(&points[points.len() - 1]);
+    }
+    out
+}
+
+/// Month boundaries (as fractional epoch-days) within the given range, for x-axis ticks
+fn month_ticks(x_min: f64, x_max: f64) -> Vec<(f64, String)> {
+    let (mut year, mut month) = civil_from_days(x_min.floor() as i64);
+    // Advance to the first month boundary >= x_min
+    month += 1;
+    if month > 12 {
+        month = 1;
+        year += 1;
+    }
+
+    let mut ticks = Vec::new();
+    loop {
+        let days = days_from_civil(year, month, 1) as f64;
+        if days > x_max {
+            break;
+        }
+        let label = format!("{} {}", MONTH_NAMES[(month - 1) as usize], year);
+        ticks.push((days, label));
+        month += 1;
+        if month > 12 {
+            month = 1;
+            year += 1;
+        }
+    }
+
+    // Thin out ticks if there are too many to label legibly
+    let stride = ticks.len().div_ceil(12).max(1);
+    ticks.into_iter().step_by(stride).collect()
+}
+
+#[component]
+pub fn WptHistoryPage(summary: ArcWptSummary) -> Element {
+    rsx! {
+        Page { title: "Status: WPT History".into(),
+            StatusHeader {}
+            StatusTabs { current_tab: "history" }
+            p {
+                dangerous_inner_html: r#"
+                This page charts Blitz's scores on the "css" subsuite of the <a href="https://github.com/web-platform-tests/wpt" target="_blank">Web Platform Tests</a> over time.
+                Scores are the percentage of subtests passing (of those that Blitz can run). Data is recorded for every commit to the main branch."#
+            }
+            hr {}
+            WptHistoryChart { summary: summary.clone() }
+            h2 { "Per-area history" }
+            WptHistorySparklines { summary }
+        }
+    }
+}
+
+const HIGHLIGHT_AREAS: &[(&str, &str)] = &[
+    ("css", "#000000"),
+    ("css/CSS2", "#e57373"),
+    ("css/css-flexbox", "#7986cb"),
+    ("css/css-grid", "#4db6ac"),
+    ("css/css-text", "#ffb74d"),
+    ("css/css-position", "#ba68c8"),
+];
+
+#[component]
+pub fn WptHistoryChart(summary: ArcWptSummary) -> Element {
+    const WIDTH: f64 = 900.0;
+    const HEIGHT: f64 = 440.0;
+    const PLOT: (f64, f64, f64, f64) = (50.0, 15.0, WIDTH - 65.0, HEIGHT - 55.0);
+    let (px, py, pw, ph) = PLOT;
+
+    let series: Vec<Series> = HIGHLIGHT_AREAS
+        .iter()
+        .filter_map(|(area, color)| area_series(&summary, area, color))
+        .collect();
+
+    let x_min = series
+        .iter()
+        .filter_map(|s| s.points.first().map(|p| p.0))
+        .fold(f64::INFINITY, f64::min);
+    let x_max = series
+        .iter()
+        .filter_map(|s| s.points.last().map(|p| p.0))
+        .fold(f64::NEG_INFINITY, f64::max);
+
+    if !x_min.is_finite() || !x_max.is_finite() {
+        return rsx!( p { "No history data available" } );
+    }
+
+    let ticks = month_ticks(x_min, x_max);
+    let x_range = (x_max - x_min).max(f64::EPSILON);
+
+    rsx! {
+        svg {
+            view_box: "0 0 {WIDTH} {HEIGHT}",
+            width: "100%",
+            font_family: "sans-serif",
+
+            // Horizontal gridlines + y-axis labels (every 10%)
+            for i in 0..=10u32 {
+                line {
+                    x1: "{px}",
+                    x2: "{px + pw}",
+                    y1: "{py + ph * (1.0 - (i as f64) / 10.0)}",
+                    y2: "{py + ph * (1.0 - (i as f64) / 10.0)}",
+                    stroke: if i % 5 == 0 { "#bbb" } else { "#e5e5e5" },
+                    stroke_width: "1",
+                }
+                text {
+                    x: "{px - 6.0}",
+                    y: "{py + ph * (1.0 - (i as f64) / 10.0) + 4.0}",
+                    text_anchor: "end",
+                    font_size: "12",
+                    fill: "#666",
+                    "{i * 10}%"
+                }
+            }
+
+            // X-axis ticks and labels (month boundaries)
+            for (days, label) in ticks {
+                line {
+                    x1: "{px + (days - x_min) / x_range * pw}",
+                    x2: "{px + (days - x_min) / x_range * pw}",
+                    y1: "{py}",
+                    y2: "{py + ph + 4.0}",
+                    stroke: "#e5e5e5",
+                    stroke_width: "1",
+                }
+                text {
+                    x: "{px + (days - x_min) / x_range * pw}",
+                    y: "{py + ph + 18.0}",
+                    text_anchor: "middle",
+                    font_size: "12",
+                    fill: "#666",
+                    {label}
+                }
+            }
+
+            // Data series
+            for s in series.iter() {
+                polyline {
+                    points: polyline_points(&s.points, x_min, x_max, PLOT),
+                    fill: "none",
+                    stroke: s.color,
+                    stroke_width: if s.name == "css" { "2.5" } else { "1.5" },
+                }
+            }
+
+            // Legend
+            for (i, s) in series.iter().enumerate() {
+                line {
+                    x1: "{px + 10.0 + (i as f64) * 140.0}",
+                    x2: "{px + 34.0 + (i as f64) * 140.0}",
+                    y1: "{HEIGHT - 10.0}",
+                    y2: "{HEIGHT - 10.0}",
+                    stroke: s.color,
+                    stroke_width: "3",
+                }
+                text {
+                    x: "{px + 40.0 + (i as f64) * 140.0}",
+                    y: "{HEIGHT - 6.0}",
+                    font_size: "12",
+                    fill: "#333",
+                    {s.name.strip_prefix("css/").unwrap_or("all css")}
+                }
+            }
+        }
+    }
+}
+
+#[component]
+pub fn WptHistorySparklines(summary: ArcWptSummary) -> Element {
+    const WIDTH: f64 = 260.0;
+    const HEIGHT: f64 = 60.0;
+    const PLOT: (f64, f64, f64, f64) = (0.0, 2.0, WIDTH, HEIGHT - 4.0);
+
+    let x_min = summary
+        .runs
+        .first()
+        .and_then(|run| parse_date(&run.date))
+        .unwrap_or(0.0);
+    let x_max = summary
+        .runs
+        .last()
+        .and_then(|run| parse_date(&run.date))
+        .unwrap_or(1.0);
+
+    rsx! {
+        div {
+            display: "grid",
+            grid_template_columns: "repeat(auto-fill, minmax(280px, 1fr))",
+            gap: "16px",
+
+            for (area_idx, area) in summary.focus_areas.iter().enumerate() {
+                {
+                    let points: Vec<(f64, f64)> = summary
+                        .runs
+                        .iter()
+                        .filter_map(|run| {
+                            Some((parse_date(&run.date)?, subtest_pass_percent(run, area_idx)?))
+                        })
+                        .collect();
+
+                    let latest = points.last().map(|p| p.1).unwrap_or(0.0);
+
+                    rsx! {
+                        div {
+                            div {
+                                display: "flex",
+                                justify_content: "space-between",
+                                font_size: "13px",
+                                span { {area.clone()} }
+                                span { {format!("{latest:.1}%")} }
+                            }
+                            svg {
+                                view_box: "0 0 {WIDTH} {HEIGHT}",
+                                width: "100%",
+                                style: "border: 1px solid #ddd",
+                                polyline {
+                                    points: polyline_points(&points, x_min, x_max, PLOT),
+                                    fill: "none",
+                                    stroke: "#7986cb",
+                                    stroke_width: "1.5",
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/routes/wpt_history.rs
+++ b/src/routes/wpt_history.rs
@@ -354,15 +354,31 @@ const TOOLTIP_JS: &str = r##"
         guide.style.display = "none";
     }
 
+    // Only show the series whose line is within this vertical distance
+    // (in viewBox units) of the cursor
+    var Y_THRESHOLD = 12;
+
     svg.addEventListener("mousemove", function (ev) {
         var rect = svg.getBoundingClientRect();
         var scale = data.width / rect.width;
         var vx = (ev.clientX - rect.left) * scale;
-        var px = data.plot[0], pw = data.plot[2];
+        var vy = (ev.clientY - rect.top) * scale;
+        var px = data.plot[0], py = data.plot[1], pw = data.plot[2], ph = data.plot[3];
         if (vx < px || vx > px + pw) { hide(); return; }
 
         var xRange = data.xMax - data.xMin;
         var run = data.runs[nearest(data.xMin + ((vx - px) / pw) * xRange)];
+
+        // Pick the single series whose line is vertically nearest the cursor
+        var best = -1, bestDist = Y_THRESHOLD;
+        for (var i = 0; i < data.series.length; i++) {
+            if (run.v[i] == null) continue;
+            var sy = py + (1 - (run.v[i][0] / run.v[i][1])) * ph;
+            var dist = Math.abs(sy - vy);
+            if (dist < bestDist) { best = i; bestDist = dist; }
+        }
+        if (best < 0) { hide(); return; }
+
         var runVx = px + ((run.x - data.xMin) / xRange) * pw;
         guide.setAttribute("x1", runVx);
         guide.setAttribute("x2", runVx);
@@ -373,13 +389,10 @@ const TOOLTIP_JS: &str = r##"
             html += "<div style='margin-bottom:4px;white-space:nowrap;overflow:hidden;" +
                 "text-overflow:ellipsis'>" + esc(run.msg) + "</div>";
         }
-        for (var i = 0; i < data.series.length; i++) {
-            if (run.v[i] == null) continue;
-            var pass = run.v[i][0], total = run.v[i][1];
-            html += "<div><span style='color:" + data.series[i].color + "'>\u25CF</span> " +
-                esc(data.series[i].name) + ": " + (100 * pass / total).toFixed(1) + "% (" +
-                pass.toLocaleString() + "/" + total.toLocaleString() + ")</div>";
-        }
+        var pass = run.v[best][0], total = run.v[best][1];
+        html += "<div><span style='color:" + data.series[best].color + "'>\u25CF</span> " +
+            esc(data.series[best].name) + ": " + (100 * pass / total).toFixed(1) + "% (" +
+            pass.toLocaleString() + "/" + total.toLocaleString() + ")</div>";
         tip.innerHTML = html;
         tip.style.display = "block";
 

--- a/src/routes/wpt_history.rs
+++ b/src/routes/wpt_history.rs
@@ -75,6 +75,19 @@ struct Series {
     points: Vec<(f64, f64)>,
 }
 
+/// Runs before this date are excluded from the charts: WPT runs for the
+/// entire prior commit history of Blitz were bulk-executed on 2026-04-13/14,
+/// so those runs' dates don't reflect real progress over time and include a
+/// number of broken runs.
+const CHART_START_DATE: &str = "2026-04-15";
+
+fn chart_runs(summary: &ScoreSummaryReport) -> impl Iterator<Item = &RunSummary> {
+    summary
+        .runs
+        .iter()
+        .filter(|run| run.date.as_str() >= CHART_START_DATE)
+}
+
 fn subtest_pass_percent(run: &RunSummary, area_idx: usize) -> Option<f64> {
     let scores = run.scores.get(area_idx)?;
     if scores.total_subtests == 0 {
@@ -89,9 +102,7 @@ fn area_series(
     color: &'static str,
 ) -> Option<Series> {
     let area_idx = summary.focus_areas.iter().position(|a| a == area)?;
-    let points: Vec<(f64, f64)> = summary
-        .runs
-        .iter()
+    let points: Vec<(f64, f64)> = chart_runs(summary)
         .filter_map(|run| Some((parse_date(&run.date)?, subtest_pass_percent(run, area_idx)?)))
         .collect();
     if points.is_empty() {
@@ -306,13 +317,11 @@ pub fn WptHistorySparklines(summary: ArcWptSummary) -> Element {
     const HEIGHT: f64 = 60.0;
     const PLOT: (f64, f64, f64, f64) = (0.0, 2.0, WIDTH, HEIGHT - 4.0);
 
-    let x_min = summary
-        .runs
-        .first()
+    let x_min = chart_runs(&summary)
+        .next()
         .and_then(|run| parse_date(&run.date))
         .unwrap_or(0.0);
-    let x_max = summary
-        .runs
+    let x_max = chart_runs(&summary)
         .last()
         .and_then(|run| parse_date(&run.date))
         .unwrap_or(1.0);
@@ -325,9 +334,7 @@ pub fn WptHistorySparklines(summary: ArcWptSummary) -> Element {
 
             for (area_idx, area) in summary.focus_areas.iter().enumerate() {
                 {
-                    let points: Vec<(f64, f64)> = summary
-                        .runs
-                        .iter()
+                    let points: Vec<(f64, f64)> = chart_runs(&summary)
                         .filter_map(|run| {
                             Some((parse_date(&run.date)?, subtest_pass_percent(run, area_idx)?))
                         })

--- a/src/wpt_history.rs
+++ b/src/wpt_history.rs
@@ -6,159 +6,208 @@ use std::{
 
 use reqwest::Client;
 use serde::Deserialize;
-use wptreport::score_summary::{RunScores, RunSummary, ScoreSummaryReport};
 
-use crate::routes::{ArcCommitMessages, ArcWptSummary};
+use crate::routes::ArcWptHistory;
 
-const SUMMARY_URL: &str =
-    "https://raw.githubusercontent.com/DioxusLabs/blitz-wpt-results/main/summary.json";
-const COMMIT_MESSAGES_URL: &str =
-    "https://raw.githubusercontent.com/DioxusLabs/blitz-wpt-results/main/commit-messages.json";
+const SUMMARY_BASE_URL: &str =
+    "https://raw.githubusercontent.com/DioxusLabs/blitz-wpt-results/main/summary";
 
-/// The compact on-disk format of summary.json: per-area scores are stored as
-/// `[total_tests, total_score, total_subtests, total_subtests_passed]` arrays
-/// (parallel to `focus_areas`)
+/// Per-area scores for a single run:
+/// `[total_tests, total_score, total_subtests, total_subtests_passed]`
+pub type ScoreTuple = (u32, f64, u32, u32);
+
+/// One entry of runs.json: metadata shared by all per-area score files
 #[derive(Deserialize)]
-struct CompactSummary {
-    focus_areas: Vec<String>,
-    runs: Vec<CompactRun>,
-}
-
-#[derive(Deserialize)]
-struct CompactRun {
+struct RunMeta {
     date: String,
+    #[allow(dead_code)]
     wpt_revision: String,
     product_revision: String,
-    scores: Vec<(u32, f64, u32, u32)>,
+    commit_message: Option<String>,
 }
 
-impl From<CompactSummary> for ScoreSummaryReport {
-    fn from(compact: CompactSummary) -> Self {
-        ScoreSummaryReport {
-            focus_areas: compact.focus_areas,
-            runs: compact
-                .runs
-                .into_iter()
-                .map(|run| RunSummary {
-                    date: run.date,
-                    wpt_revision: run.wpt_revision,
-                    product_revision: run.product_revision,
-                    scores: run
-                        .scores
-                        .into_iter()
-                        .map(
-                            |(total_tests, total_score, total_subtests, total_subtests_passed)| {
-                                RunScores {
-                                    total_tests,
-                                    total_score,
-                                    total_subtests,
-                                    total_subtests_passed,
-                                }
-                            },
-                        )
-                        .collect(),
-                })
-                .collect(),
-        }
+#[derive(Deserialize)]
+struct RunsFile {
+    runs: Vec<RunMeta>,
+}
+
+/// One summary/areas/<group>.json file: `scores` has one row per run
+/// (index-aligned with runs.json), each row parallel to `focus_areas`
+#[derive(Deserialize)]
+struct AreaFile {
+    focus_areas: Vec<String>,
+    scores: Vec<Vec<Option<ScoreTuple>>>,
+}
+
+/// The merged history for one group of areas (one top-level WPT folder)
+pub struct WptHistory {
+    pub focus_areas: Vec<String>,
+    pub runs: Vec<HistoryRun>,
+}
+
+pub struct HistoryRun {
+    pub date: String,
+    pub product_revision: String,
+    pub commit_message: Option<String>,
+    pub scores: Vec<Option<ScoreTuple>>,
+}
+
+/// The group (data file) that holds history for a given WPT folder path:
+/// "css" itself and its direct children are in the "css" group; deeper
+/// folders are in the group named for their top-level folder.
+pub fn history_group(area: &str) -> &str {
+    match area.split('/').nth(1) {
+        Some(second) => second,
+        None => "css",
     }
 }
 
 pub static WPT_HISTORY_CACHE: WptHistoryCache = WptHistoryCache::new();
 
-pub struct WptHistoryCache(Mutex<Option<Arc<WptHistoryCacheEntry>>>);
+pub struct WptHistoryCacheEntry {
+    pub runs_etag: Option<Arc<str>>,
+    pub area_etag: Option<Arc<str>>,
+    pub cached_at: Instant,
+    pub history: ArcWptHistory,
+}
+
+/// A cache of merged history data, keyed by group name
+pub struct WptHistoryCache(Mutex<Option<HashMap<String, Arc<WptHistoryCacheEntry>>>>);
 impl WptHistoryCache {
     const fn new() -> Self {
         Self(Mutex::new(None))
     }
 
-    pub fn get_cloned(&self) -> Option<Arc<WptHistoryCacheEntry>> {
-        (*self.0.lock().unwrap()).clone()
+    pub fn get_cloned(&self, group: &str) -> Option<Arc<WptHistoryCacheEntry>> {
+        self.0.lock().unwrap().as_ref()?.get(group).cloned()
     }
 
-    pub fn update(
-        &self,
-        etag: Option<Arc<str>>,
-        summary: ArcWptSummary,
-        commit_messages: ArcCommitMessages,
-    ) {
-        let cached_at = Instant::now();
-        *self.0.lock().unwrap() = Some(Arc::new(WptHistoryCacheEntry {
-            etag,
-            cached_at,
-            summary,
-            commit_messages,
-        }));
+    fn update(&self, group: &str, entry: WptHistoryCacheEntry) {
+        self.0
+            .lock()
+            .unwrap()
+            .get_or_insert_with(HashMap::new)
+            .insert(group.to_string(), Arc::new(entry));
     }
 
-    pub fn mark_as_fresh(&self) {
-        let cached_at = Instant::now();
+    fn mark_as_fresh(&self, group: &str) {
         let mut inner = self.0.lock().unwrap();
-        if let Some(entry) = inner.take() {
-            *inner = Some(Arc::new(WptHistoryCacheEntry {
-                cached_at,
-                etag: entry.etag.clone(),
-                summary: entry.summary.clone(),
-                commit_messages: entry.commit_messages.clone(),
-            }));
-        }
+        let Some(entry) = inner.as_mut().and_then(|map| map.get_mut(group)) else {
+            return;
+        };
+        *entry = Arc::new(WptHistoryCacheEntry {
+            cached_at: Instant::now(),
+            runs_etag: entry.runs_etag.clone(),
+            area_etag: entry.area_etag.clone(),
+            history: entry.history.clone(),
+        });
     }
 }
 
-pub struct WptHistoryCacheEntry {
-    pub etag: Option<Arc<str>>,
-    pub cached_at: Instant,
-    pub summary: ArcWptSummary,
-    pub commit_messages: ArcCommitMessages,
-}
-
-pub async fn load_wpt_history(etag: Option<Arc<str>>) {
-    println!("Checking for new WPT history summary...");
-
-    let client = Client::new();
-    let mut builder = client.get(SUMMARY_URL);
-
-    if let Some(etag) = etag.as_ref() {
+async fn fetch(
+    client: &Client,
+    url: &str,
+    etag: Option<&Arc<str>>,
+) -> Option<(Option<Arc<str>>, Option<Vec<u8>>)> {
+    let mut builder = client.get(url);
+    if let Some(etag) = etag {
         builder = builder.header("If-None-Match", &**etag);
     }
-    let result = builder.send().await.unwrap();
-
+    let result = builder.send().await.ok()?;
     if result.status() == 304 {
-        println!("WPT history summary unchanged");
-        WPT_HISTORY_CACHE.mark_as_fresh();
-        return;
+        return Some((etag.cloned(), None));
     }
-
+    if !result.status().is_success() {
+        println!("Failed to fetch {url}: HTTP {}", result.status());
+        return None;
+    }
     let etag = result
         .headers()
         .get("etag")
         .and_then(|header| header.to_str().ok())
         .map(Arc::from);
+    Some((etag, Some(result.bytes().await.ok()?.to_vec())))
+}
 
-    println!("New WPT history summary found. etag: {etag:?}");
+/// Fetch (or revalidate) the history data for one group
+pub async fn load_wpt_history(group: String) {
+    println!("Checking for new WPT history data for group {group:?}...");
 
-    let body = result.bytes().await.unwrap();
-    let compact: CompactSummary = serde_json::from_slice(&body).unwrap();
-    let summary = ScoreSummaryReport::from(compact);
+    let existing = WPT_HISTORY_CACHE.get_cloned(&group);
+    let (runs_etag, area_etag) = existing
+        .as_ref()
+        .map(|entry| (entry.runs_etag.clone(), entry.area_etag.clone()))
+        .unwrap_or((None, None));
 
-    // Commit messages are optional: tooltips degrade gracefully without them
-    let commit_messages: HashMap<String, String> = match client
-        .get(COMMIT_MESSAGES_URL)
-        .send()
-        .await
-        .and_then(|res| res.error_for_status())
-    {
-        Ok(res) => serde_json::from_slice(&res.bytes().await.unwrap()).unwrap_or_default(),
-        Err(err) => {
-            println!("Failed to fetch commit messages: {err}");
-            HashMap::new()
+    let client = Client::new();
+    let runs_url = format!("{SUMMARY_BASE_URL}/runs.json");
+    let area_url = format!("{SUMMARY_BASE_URL}/areas/{group}.json");
+    let results = tokio::join!(
+        fetch(&client, &runs_url, runs_etag.as_ref()),
+        fetch(&client, &area_url, area_etag.as_ref()),
+    );
+    let (Some(runs_result), Some(area_result)) = results else {
+        return;
+    };
+
+    if runs_result.1.is_none() && area_result.1.is_none() {
+        println!("WPT history data for group {group:?} unchanged");
+        WPT_HISTORY_CACHE.mark_as_fresh(&group);
+        return;
+    }
+
+    // If only one of the two files changed, refetch the other unconditionally
+    // so the pair stays consistent (they must be index-aligned)
+    let (runs_etag, runs_body) = match runs_result {
+        (etag, Some(body)) => (etag, body),
+        (_, None) => {
+            let Some((etag, body)) = fetch(&client, &runs_url, None).await else {
+                return;
+            };
+            (etag, body.unwrap())
+        }
+    };
+    let (area_etag, area_body) = match area_result {
+        (etag, Some(body)) => (etag, body),
+        (_, None) => {
+            let Some((etag, body)) = fetch(&client, &area_url, None).await else {
+                return;
+            };
+            (etag, body.unwrap())
         }
     };
 
-    WPT_HISTORY_CACHE.update(
-        etag,
-        ArcWptSummary(Arc::new(summary)),
-        ArcCommitMessages(Arc::new(commit_messages)),
+    let runs_file: RunsFile = serde_json::from_slice(&runs_body).unwrap();
+    let area_file: AreaFile = serde_json::from_slice(&area_body).unwrap();
+    assert_eq!(
+        runs_file.runs.len(),
+        area_file.scores.len(),
+        "area file {group} is misaligned with runs.json"
     );
 
-    println!("New WPT history summary processed and cached.");
+    let history = WptHistory {
+        focus_areas: area_file.focus_areas,
+        runs: runs_file
+            .runs
+            .into_iter()
+            .zip(area_file.scores)
+            .map(|(meta, scores)| HistoryRun {
+                date: meta.date,
+                product_revision: meta.product_revision,
+                commit_message: meta.commit_message,
+                scores,
+            })
+            .collect(),
+    };
+
+    println!("New WPT history data for group {group:?} processed and cached.");
+    WPT_HISTORY_CACHE.update(
+        &group,
+        WptHistoryCacheEntry {
+            runs_etag,
+            area_etag,
+            cached_at: Instant::now(),
+            history: ArcWptHistory(Arc::new(history)),
+        },
+    );
 }

--- a/src/wpt_history.rs
+++ b/src/wpt_history.rs
@@ -52,13 +52,16 @@ pub struct HistoryRun {
     pub scores: Vec<Option<ScoreTuple>>,
 }
 
-/// The group (data file) that holds history for a given WPT folder path:
-/// "css" itself and its direct children are in the "css" group; deeper
-/// folders are in the group named for their top-level folder.
-pub fn history_group(area: &str) -> &str {
-    match area.split('/').nth(1) {
-        Some(second) => second,
-        None => "css",
+/// The group (data file, nested under the root suite's directory) that holds
+/// history for a given WPT folder path: the root suite itself and its direct
+/// children are in the root group (e.g. "css/css"); deeper folders are in
+/// the group named for their top-level folder (e.g. "css/css-flexbox").
+pub fn history_group(area: &str) -> String {
+    let mut components = area.split('/');
+    let root = components.next().unwrap_or("css");
+    match components.next() {
+        Some(second) => format!("{root}/{second}"),
+        None => format!("{root}/{root}"),
     }
 }
 

--- a/src/wpt_history.rs
+++ b/src/wpt_history.rs
@@ -1,0 +1,85 @@
+use std::{
+    sync::{Arc, Mutex},
+    time::Instant,
+};
+
+use reqwest::Client;
+use wptreport::score_summary::ScoreSummaryReport;
+
+use crate::routes::ArcWptSummary;
+
+const SUMMARY_URL: &str =
+    "https://raw.githubusercontent.com/DioxusLabs/blitz-wpt-results/main/summary.json";
+
+pub static WPT_HISTORY_CACHE: WptHistoryCache = WptHistoryCache::new();
+
+pub struct WptHistoryCache(Mutex<Option<Arc<WptHistoryCacheEntry>>>);
+impl WptHistoryCache {
+    const fn new() -> Self {
+        Self(Mutex::new(None))
+    }
+
+    pub fn get_cloned(&self) -> Option<Arc<WptHistoryCacheEntry>> {
+        (*self.0.lock().unwrap()).clone()
+    }
+
+    pub fn update(&self, etag: Option<Arc<str>>, summary: ArcWptSummary) {
+        let cached_at = Instant::now();
+        *self.0.lock().unwrap() = Some(Arc::new(WptHistoryCacheEntry {
+            etag,
+            cached_at,
+            summary,
+        }));
+    }
+
+    pub fn mark_as_fresh(&self) {
+        let cached_at = Instant::now();
+        let mut inner = self.0.lock().unwrap();
+        if let Some(entry) = inner.take() {
+            *inner = Some(Arc::new(WptHistoryCacheEntry {
+                cached_at,
+                etag: entry.etag.clone(),
+                summary: entry.summary.clone(),
+            }));
+        }
+    }
+}
+
+pub struct WptHistoryCacheEntry {
+    pub etag: Option<Arc<str>>,
+    pub cached_at: Instant,
+    pub summary: ArcWptSummary,
+}
+
+pub async fn load_wpt_history(etag: Option<Arc<str>>) {
+    println!("Checking for new WPT history summary...");
+
+    let client = Client::new();
+    let mut builder = client.get(SUMMARY_URL);
+
+    if let Some(etag) = etag.as_ref() {
+        builder = builder.header("If-None-Match", &**etag);
+    }
+    let result = builder.send().await.unwrap();
+
+    if result.status() == 304 {
+        println!("WPT history summary unchanged");
+        WPT_HISTORY_CACHE.mark_as_fresh();
+        return;
+    }
+
+    let etag = result
+        .headers()
+        .get("etag")
+        .and_then(|header| header.to_str().ok())
+        .map(Arc::from);
+
+    println!("New WPT history summary found. etag: {etag:?}");
+
+    let body = result.bytes().await.unwrap();
+    let summary: ScoreSummaryReport = serde_json::from_slice(&body).unwrap();
+
+    WPT_HISTORY_CACHE.update(etag, ArcWptSummary(Arc::new(summary)));
+
+    println!("New WPT history summary processed and cached.");
+}

--- a/src/wpt_history.rs
+++ b/src/wpt_history.rs
@@ -5,7 +5,8 @@ use std::{
 };
 
 use reqwest::Client;
-use wptreport::score_summary::ScoreSummaryReport;
+use serde::Deserialize;
+use wptreport::score_summary::{RunScores, RunSummary, ScoreSummaryReport};
 
 use crate::routes::{ArcCommitMessages, ArcWptSummary};
 
@@ -13,6 +14,54 @@ const SUMMARY_URL: &str =
     "https://raw.githubusercontent.com/DioxusLabs/blitz-wpt-results/main/summary.json";
 const COMMIT_MESSAGES_URL: &str =
     "https://raw.githubusercontent.com/DioxusLabs/blitz-wpt-results/main/commit-messages.json";
+
+/// The compact on-disk format of summary.json: per-area scores are stored as
+/// `[total_tests, total_score, total_subtests, total_subtests_passed]` arrays
+/// (parallel to `focus_areas`)
+#[derive(Deserialize)]
+struct CompactSummary {
+    focus_areas: Vec<String>,
+    runs: Vec<CompactRun>,
+}
+
+#[derive(Deserialize)]
+struct CompactRun {
+    date: String,
+    wpt_revision: String,
+    product_revision: String,
+    scores: Vec<(u32, f64, u32, u32)>,
+}
+
+impl From<CompactSummary> for ScoreSummaryReport {
+    fn from(compact: CompactSummary) -> Self {
+        ScoreSummaryReport {
+            focus_areas: compact.focus_areas,
+            runs: compact
+                .runs
+                .into_iter()
+                .map(|run| RunSummary {
+                    date: run.date,
+                    wpt_revision: run.wpt_revision,
+                    product_revision: run.product_revision,
+                    scores: run
+                        .scores
+                        .into_iter()
+                        .map(
+                            |(total_tests, total_score, total_subtests, total_subtests_passed)| {
+                                RunScores {
+                                    total_tests,
+                                    total_score,
+                                    total_subtests,
+                                    total_subtests_passed,
+                                }
+                            },
+                        )
+                        .collect(),
+                })
+                .collect(),
+        }
+    }
+}
 
 pub static WPT_HISTORY_CACHE: WptHistoryCache = WptHistoryCache::new();
 
@@ -88,7 +137,8 @@ pub async fn load_wpt_history(etag: Option<Arc<str>>) {
     println!("New WPT history summary found. etag: {etag:?}");
 
     let body = result.bytes().await.unwrap();
-    let summary: ScoreSummaryReport = serde_json::from_slice(&body).unwrap();
+    let compact: CompactSummary = serde_json::from_slice(&body).unwrap();
+    let summary = ScoreSummaryReport::from(compact);
 
     // Commit messages are optional: tooltips degrade gracefully without them
     let commit_messages: HashMap<String, String> = match client

--- a/src/wpt_history.rs
+++ b/src/wpt_history.rs
@@ -18,12 +18,12 @@ pub type ScoreTuple = (u32, f64, u32, u32);
 
 /// One entry of runs.json: metadata shared by all per-area score files
 #[derive(Deserialize)]
-struct RunMeta {
-    date: String,
+pub struct RunMeta {
+    pub date: String,
     #[allow(dead_code)]
-    wpt_revision: String,
-    product_revision: String,
-    commit_message: Option<String>,
+    pub wpt_revision: String,
+    pub product_revision: String,
+    pub commit_message: Option<String>,
 }
 
 #[derive(Deserialize)]
@@ -31,15 +31,14 @@ struct RunsFile {
     runs: Vec<RunMeta>,
 }
 
-/// One summary/areas/<group>.json file: `scores` has one row per run
-/// (index-aligned with runs.json), each row parallel to `focus_areas`
+/// One summary/areas/<area>.json file: `scores` has one entry per run,
+/// index-aligned with runs.json
 #[derive(Deserialize)]
 struct AreaFile {
-    focus_areas: Vec<String>,
-    scores: Vec<Vec<Option<ScoreTuple>>>,
+    scores: Vec<Option<ScoreTuple>>,
 }
 
-/// The merged history for one group of areas (one top-level WPT folder)
+/// The merged history for a set of areas
 pub struct WptHistory {
     pub focus_areas: Vec<String>,
     pub runs: Vec<HistoryRun>,
@@ -52,58 +51,62 @@ pub struct HistoryRun {
     pub scores: Vec<Option<ScoreTuple>>,
 }
 
-/// The group (data file, nested under the root suite's directory) that holds
-/// history for a given WPT folder path: the root suite itself and its direct
-/// children are in the root group (e.g. "css/css"); deeper folders are in
-/// the group named for their top-level folder (e.g. "css/css-flexbox").
-pub fn history_group(area: &str) -> String {
-    let mut components = area.split('/');
-    let root = components.next().unwrap_or("css");
-    match components.next() {
-        Some(second) => format!("{root}/{second}"),
-        None => format!("{root}/{root}"),
+pub static WPT_HISTORY_CACHE: WptHistoryCache = WptHistoryCache::new();
+
+/// Cached summary data. All summary files change together (a new run appends
+/// one entry to runs.json and to every area file), so the whole cache is
+/// keyed on runs.json's ETag: while it revalidates as unchanged, every cached
+/// area file is still valid, and area files are only fetched on first use or
+/// when runs.json changes.
+pub struct WptHistoryCacheEntry {
+    pub runs_etag: Option<Arc<str>>,
+    pub cached_at: Instant,
+    runs: Arc<Vec<RunMeta>>,
+    areas: HashMap<String, Arc<Vec<Option<ScoreTuple>>>>,
+}
+
+impl WptHistoryCacheEntry {
+    pub fn contains_areas(&self, areas: &[String]) -> bool {
+        areas.iter().all(|area| self.areas.contains_key(area))
+    }
+
+    /// Build the merged history for a set of areas (silently dropping any
+    /// that have no data file)
+    pub fn merged(&self, areas: &[String]) -> ArcWptHistory {
+        let present: Vec<(&String, &Arc<Vec<Option<ScoreTuple>>>)> = areas
+            .iter()
+            .filter_map(|area| self.areas.get(area).map(|scores| (area, scores)))
+            .collect();
+        let runs = self
+            .runs
+            .iter()
+            .enumerate()
+            .map(|(i, meta)| HistoryRun {
+                date: meta.date.clone(),
+                product_revision: meta.product_revision.clone(),
+                commit_message: meta.commit_message.clone(),
+                scores: present.iter().map(|(_, scores)| scores[i]).collect(),
+            })
+            .collect();
+        ArcWptHistory(Arc::new(WptHistory {
+            focus_areas: present.iter().map(|(area, _)| (*area).clone()).collect(),
+            runs,
+        }))
     }
 }
 
-pub static WPT_HISTORY_CACHE: WptHistoryCache = WptHistoryCache::new();
-
-pub struct WptHistoryCacheEntry {
-    pub runs_etag: Option<Arc<str>>,
-    pub area_etag: Option<Arc<str>>,
-    pub cached_at: Instant,
-    pub history: ArcWptHistory,
-}
-
-/// A cache of merged history data, keyed by group name
-pub struct WptHistoryCache(Mutex<Option<HashMap<String, Arc<WptHistoryCacheEntry>>>>);
+pub struct WptHistoryCache(Mutex<Option<Arc<WptHistoryCacheEntry>>>);
 impl WptHistoryCache {
     const fn new() -> Self {
         Self(Mutex::new(None))
     }
 
-    pub fn get_cloned(&self, group: &str) -> Option<Arc<WptHistoryCacheEntry>> {
-        self.0.lock().unwrap().as_ref()?.get(group).cloned()
+    pub fn get_cloned(&self) -> Option<Arc<WptHistoryCacheEntry>> {
+        self.0.lock().unwrap().clone()
     }
 
-    fn update(&self, group: &str, entry: WptHistoryCacheEntry) {
-        self.0
-            .lock()
-            .unwrap()
-            .get_or_insert_with(HashMap::new)
-            .insert(group.to_string(), Arc::new(entry));
-    }
-
-    fn mark_as_fresh(&self, group: &str) {
-        let mut inner = self.0.lock().unwrap();
-        let Some(entry) = inner.as_mut().and_then(|map| map.get_mut(group)) else {
-            return;
-        };
-        *entry = Arc::new(WptHistoryCacheEntry {
-            cached_at: Instant::now(),
-            runs_etag: entry.runs_etag.clone(),
-            area_etag: entry.area_etag.clone(),
-            history: entry.history.clone(),
-        });
+    fn update(&self, entry: WptHistoryCacheEntry) {
+        *self.0.lock().unwrap() = Some(Arc::new(entry));
     }
 }
 
@@ -132,85 +135,106 @@ async fn fetch(
     Some((etag, Some(result.bytes().await.ok()?.to_vec())))
 }
 
-/// Fetch (or revalidate) the history data for one group
-pub async fn load_wpt_history(group: String) {
-    println!("Checking for new WPT history data for group {group:?}...");
+/// Fetch the score files for a set of areas in parallel, dropping any that
+/// fail to fetch or don't align with the run count
+async fn fetch_areas(
+    client: &Client,
+    areas: &[String],
+    run_count: usize,
+) -> HashMap<String, Arc<Vec<Option<ScoreTuple>>>> {
+    let handles: Vec<_> = areas
+        .iter()
+        .map(|area| {
+            let client = client.clone();
+            let url = format!("{SUMMARY_BASE_URL}/areas/{area}.json");
+            tokio::spawn(async move { fetch(&client, &url, None).await })
+        })
+        .collect();
 
-    let existing = WPT_HISTORY_CACHE.get_cloned(&group);
-    let (runs_etag, area_etag) = existing
-        .as_ref()
-        .map(|entry| (entry.runs_etag.clone(), entry.area_etag.clone()))
-        .unwrap_or((None, None));
+    let mut map = HashMap::new();
+    for (area, handle) in areas.iter().zip(handles) {
+        let Ok(Some((_, Some(body)))) = handle.await else {
+            continue;
+        };
+        let Ok(file) = serde_json::from_slice::<AreaFile>(&body) else {
+            println!("Area file {area} is not valid JSON");
+            continue;
+        };
+        if file.scores.len() != run_count {
+            println!("Area file {area} is misaligned with runs.json; skipping");
+            continue;
+        }
+        map.insert(area.clone(), Arc::new(file.scores));
+    }
+    map
+}
+
+/// Fetch (or revalidate) the history data for a set of areas
+pub async fn load_wpt_history(areas: Vec<String>) {
+    println!(
+        "Checking for new WPT history data ({} areas)...",
+        areas.len()
+    );
+
+    let existing = WPT_HISTORY_CACHE.get_cloned();
+    let runs_etag = existing.as_ref().and_then(|entry| entry.runs_etag.clone());
 
     let client = Client::new();
     let runs_url = format!("{SUMMARY_BASE_URL}/runs.json");
-    let area_url = format!("{SUMMARY_BASE_URL}/areas/{group}.json");
-    let results = tokio::join!(
-        fetch(&client, &runs_url, runs_etag.as_ref()),
-        fetch(&client, &area_url, area_etag.as_ref()),
-    );
-    let (Some(runs_result), Some(area_result)) = results else {
+    let Some((runs_etag, runs_body)) = fetch(&client, &runs_url, runs_etag.as_ref()).await else {
         return;
     };
 
-    if runs_result.1.is_none() && area_result.1.is_none() {
-        println!("WPT history data for group {group:?} unchanged");
-        WPT_HISTORY_CACHE.mark_as_fresh(&group);
-        return;
+    match (runs_body, existing) {
+        // runs.json unchanged: all cached area files are still valid; fetch
+        // only the requested areas we don't have yet
+        (None, Some(existing)) => {
+            let missing: Vec<String> = areas
+                .iter()
+                .filter(|area| !existing.areas.contains_key(*area))
+                .cloned()
+                .collect();
+            let mut cached_areas = existing.areas.clone();
+            if !missing.is_empty() {
+                println!(
+                    "WPT history data unchanged; fetching {} new areas",
+                    missing.len()
+                );
+                cached_areas.extend(fetch_areas(&client, &missing, existing.runs.len()).await);
+            } else {
+                println!("WPT history data unchanged");
+            }
+            WPT_HISTORY_CACHE.update(WptHistoryCacheEntry {
+                runs_etag,
+                cached_at: Instant::now(),
+                runs: existing.runs.clone(),
+                areas: cached_areas,
+            });
+        }
+        // runs.json changed (or first load): all cached area files are
+        // stale; refetch the requested areas against the new run list
+        (Some(body), _) => {
+            let runs_file: RunsFile = match serde_json::from_slice(&body) {
+                Ok(file) => file,
+                Err(err) => {
+                    println!("runs.json is not valid JSON: {err}");
+                    return;
+                }
+            };
+            let cached_areas = fetch_areas(&client, &areas, runs_file.runs.len()).await;
+            println!(
+                "New WPT history data cached ({} runs, {} areas)",
+                runs_file.runs.len(),
+                cached_areas.len()
+            );
+            WPT_HISTORY_CACHE.update(WptHistoryCacheEntry {
+                runs_etag,
+                cached_at: Instant::now(),
+                runs: Arc::new(runs_file.runs),
+                areas: cached_areas,
+            });
+        }
+        // 304 without a cache entry shouldn't happen (no etag was sent)
+        (None, None) => {}
     }
-
-    // If only one of the two files changed, refetch the other unconditionally
-    // so the pair stays consistent (they must be index-aligned)
-    let (runs_etag, runs_body) = match runs_result {
-        (etag, Some(body)) => (etag, body),
-        (_, None) => {
-            let Some((etag, body)) = fetch(&client, &runs_url, None).await else {
-                return;
-            };
-            (etag, body.unwrap())
-        }
-    };
-    let (area_etag, area_body) = match area_result {
-        (etag, Some(body)) => (etag, body),
-        (_, None) => {
-            let Some((etag, body)) = fetch(&client, &area_url, None).await else {
-                return;
-            };
-            (etag, body.unwrap())
-        }
-    };
-
-    let runs_file: RunsFile = serde_json::from_slice(&runs_body).unwrap();
-    let area_file: AreaFile = serde_json::from_slice(&area_body).unwrap();
-    assert_eq!(
-        runs_file.runs.len(),
-        area_file.scores.len(),
-        "area file {group} is misaligned with runs.json"
-    );
-
-    let history = WptHistory {
-        focus_areas: area_file.focus_areas,
-        runs: runs_file
-            .runs
-            .into_iter()
-            .zip(area_file.scores)
-            .map(|(meta, scores)| HistoryRun {
-                date: meta.date,
-                product_revision: meta.product_revision,
-                commit_message: meta.commit_message,
-                scores,
-            })
-            .collect(),
-    };
-
-    println!("New WPT history data for group {group:?} processed and cached.");
-    WPT_HISTORY_CACHE.update(
-        &group,
-        WptHistoryCacheEntry {
-            runs_etag,
-            area_etag,
-            cached_at: Instant::now(),
-            history: ArcWptHistory(Arc::new(history)),
-        },
-    );
 }

--- a/src/wpt_history.rs
+++ b/src/wpt_history.rs
@@ -1,4 +1,5 @@
 use std::{
+    collections::HashMap,
     sync::{Arc, Mutex},
     time::Instant,
 };
@@ -6,10 +7,12 @@ use std::{
 use reqwest::Client;
 use wptreport::score_summary::ScoreSummaryReport;
 
-use crate::routes::ArcWptSummary;
+use crate::routes::{ArcCommitMessages, ArcWptSummary};
 
 const SUMMARY_URL: &str =
     "https://raw.githubusercontent.com/DioxusLabs/blitz-wpt-results/main/summary.json";
+const COMMIT_MESSAGES_URL: &str =
+    "https://raw.githubusercontent.com/DioxusLabs/blitz-wpt-results/main/commit-messages.json";
 
 pub static WPT_HISTORY_CACHE: WptHistoryCache = WptHistoryCache::new();
 
@@ -23,12 +26,18 @@ impl WptHistoryCache {
         (*self.0.lock().unwrap()).clone()
     }
 
-    pub fn update(&self, etag: Option<Arc<str>>, summary: ArcWptSummary) {
+    pub fn update(
+        &self,
+        etag: Option<Arc<str>>,
+        summary: ArcWptSummary,
+        commit_messages: ArcCommitMessages,
+    ) {
         let cached_at = Instant::now();
         *self.0.lock().unwrap() = Some(Arc::new(WptHistoryCacheEntry {
             etag,
             cached_at,
             summary,
+            commit_messages,
         }));
     }
 
@@ -40,6 +49,7 @@ impl WptHistoryCache {
                 cached_at,
                 etag: entry.etag.clone(),
                 summary: entry.summary.clone(),
+                commit_messages: entry.commit_messages.clone(),
             }));
         }
     }
@@ -49,6 +59,7 @@ pub struct WptHistoryCacheEntry {
     pub etag: Option<Arc<str>>,
     pub cached_at: Instant,
     pub summary: ArcWptSummary,
+    pub commit_messages: ArcCommitMessages,
 }
 
 pub async fn load_wpt_history(etag: Option<Arc<str>>) {
@@ -79,7 +90,25 @@ pub async fn load_wpt_history(etag: Option<Arc<str>>) {
     let body = result.bytes().await.unwrap();
     let summary: ScoreSummaryReport = serde_json::from_slice(&body).unwrap();
 
-    WPT_HISTORY_CACHE.update(etag, ArcWptSummary(Arc::new(summary)));
+    // Commit messages are optional: tooltips degrade gracefully without them
+    let commit_messages: HashMap<String, String> = match client
+        .get(COMMIT_MESSAGES_URL)
+        .send()
+        .await
+        .and_then(|res| res.error_for_status())
+    {
+        Ok(res) => serde_json::from_slice(&res.bytes().await.unwrap()).unwrap_or_default(),
+        Err(err) => {
+            println!("Failed to fetch commit messages: {err}");
+            HashMap::new()
+        }
+    };
+
+    WPT_HISTORY_CACHE.update(
+        etag,
+        ArcWptSummary(Arc::new(summary)),
+        ArcCommitMessages(Arc::new(commit_messages)),
+    );
 
     println!("New WPT history summary processed and cached.");
 }

--- a/static/wpt-history-tooltip.js
+++ b/static/wpt-history-tooltip.js
@@ -70,16 +70,36 @@ document.querySelectorAll("script[data-wpt-history-data]").forEach(function (dat
         var prev = runIdx > 0 ? data.runs[runIdx - 1] : null;
 
         // Pick the single series whose line is vertically nearest the cursor.
-        // Percentages use the latest run's subtest total as the denominator,
-        // matching the plotted lines.
+        // Distance is measured to the line as drawn (interpolated between the
+        // runs bracketing the cursor) so steep jumps stay hoverable anywhere
+        // along their length. Percentages use the latest run's subtest total
+        // as the denominator, matching the plotted lines.
+        function lineYAtCursor(i) {
+            var runs = data.runs, latest = data.series[i].latest;
+            var before = -1, after = -1;
+            for (var j = data.first; j < runs.length; j++) {
+                if (runs[j].v[i] == null) continue;
+                if (runs[j].x <= data.xMin + ((vx - px) / pw) * xRange) before = j;
+                else { after = j; break; }
+            }
+            if (before < 0 && after < 0) return null;
+            if (before < 0) before = after;
+            if (after < 0) after = before;
+            function yOf(j) { return py + (1 - runs[j].v[i][0] / latest) * ph; }
+            function xOf(j) { return px + ((runs[j].x - data.xMin) / xRange) * pw; }
+            if (xOf(after) === xOf(before)) return yOf(before);
+            var t = (vx - xOf(before)) / (xOf(after) - xOf(before));
+            return yOf(before) + t * (yOf(after) - yOf(before));
+        }
         var best = -1, bestDist = Y_THRESHOLD;
         for (var i = 0; i < data.series.length; i++) {
-            if (run.v[i] == null || !data.series[i].latest) continue;
-            var sy = py + (1 - (run.v[i][0] / data.series[i].latest)) * ph;
+            if (!data.series[i].latest) continue;
+            var sy = lineYAtCursor(i);
+            if (sy == null) continue;
             var dist = Math.abs(sy - vy);
             if (dist < bestDist) { best = i; bestDist = dist; }
         }
-        if (best < 0) { hide(); return; }
+        if (best < 0 || run.v[best] == null) { hide(); return; }
 
         // Prefer a nearby commit whose value actually changed for this
         // series over the strictly-nearest commit

--- a/static/wpt-history-tooltip.js
+++ b/static/wpt-history-tooltip.js
@@ -1,0 +1,143 @@
+// Hover tooltip for WPT history charts (progressive enhancement): reads run
+// data from each chart's JSON blob and shows the nearest run's commit id,
+// commit message, and pass percentages for the nearest line.
+document.querySelectorAll("script[data-wpt-history-data]").forEach(function (dataEl) {
+    if (dataEl.dataset.tooltipInit) return;
+    dataEl.dataset.tooltipInit = "1";
+    var container = dataEl.parentElement;
+    var svg = container.querySelector("svg");
+    var data = JSON.parse(dataEl.textContent);
+    if (!svg || !data.runs.length) return;
+
+    var tip = document.createElement("div");
+    tip.style.cssText =
+        "position:absolute;pointer-events:none;display:none;background:rgba(255,255,255,0.96);" +
+        "border:1px solid #999;border-radius:4px;padding:6px 8px;font:12px sans-serif;" +
+        "box-shadow:0 1px 4px rgba(0,0,0,0.25);z-index:10;width:260px;box-sizing:border-box";
+    container.appendChild(tip);
+
+    var guide = document.createElementNS("http://www.w3.org/2000/svg", "line");
+    guide.setAttribute("stroke", "#888");
+    guide.setAttribute("stroke-dasharray", "3,3");
+    guide.setAttribute("y1", data.plot[1]);
+    guide.setAttribute("y2", data.plot[1] + data.plot[3]);
+    guide.style.display = "none";
+    svg.appendChild(guide);
+
+    var dot = document.createElementNS("http://www.w3.org/2000/svg", "circle");
+    dot.setAttribute("r", 4);
+    dot.setAttribute("stroke", "white");
+    dot.setAttribute("stroke-width", 1.5);
+    dot.style.display = "none";
+    svg.appendChild(dot);
+
+    function esc(s) {
+        return s.replace(/&/g, "&amp;").replace(/</g, "&lt;");
+    }
+
+    // Nearest hoverable run (runs before data.first only serve as deltas)
+    function nearest(x) {
+        var runs = data.runs, lo = data.first, hi = runs.length - 1;
+        while (lo < hi) {
+            var mid = (lo + hi) >> 1;
+            if (runs[mid].x < x) lo = mid + 1; else hi = mid;
+        }
+        if (lo > data.first && Math.abs(runs[lo - 1].x - x) < Math.abs(runs[lo].x - x)) lo--;
+        return lo;
+    }
+
+    function hide() {
+        tip.style.display = "none";
+        guide.style.display = "none";
+        dot.style.display = "none";
+    }
+
+    // Only show the series whose line is within this vertical distance
+    // (in viewBox units) of the cursor
+    var Y_THRESHOLD = 12;
+
+    svg.addEventListener("mousemove", function (ev) {
+        var rect = svg.getBoundingClientRect();
+        var scale = data.width / rect.width;
+        var vx = (ev.clientX - rect.left) * scale;
+        var vy = (ev.clientY - rect.top) * scale;
+        var px = data.plot[0], py = data.plot[1], pw = data.plot[2], ph = data.plot[3];
+        if (vx < px || vx > px + pw) { hide(); return; }
+
+        var xRange = data.xMax - data.xMin;
+        var runIdx = nearest(data.xMin + ((vx - px) / pw) * xRange);
+        var run = data.runs[runIdx];
+        var prev = runIdx > 0 ? data.runs[runIdx - 1] : null;
+
+        // Pick the single series whose line is vertically nearest the cursor
+        var best = -1, bestDist = Y_THRESHOLD;
+        for (var i = 0; i < data.series.length; i++) {
+            if (run.v[i] == null) continue;
+            var sy = py + (1 - (run.v[i][0] / run.v[i][1])) * ph;
+            var dist = Math.abs(sy - vy);
+            if (dist < bestDist) { best = i; bestDist = dist; }
+        }
+        if (best < 0) { hide(); return; }
+
+        // Prefer a nearby commit whose value actually changed for this
+        // series over the strictly-nearest commit
+        var SNAP_PX = 10;
+        function screenX(i) { return px + ((data.runs[i].x - data.xMin) / xRange) * pw; }
+        function hasChange(i) {
+            var cur = data.runs[i].v[best];
+            if (cur == null) return false;
+            var p = i > 0 ? data.runs[i - 1].v[best] : null;
+            return p == null || cur[0] !== p[0] || cur[1] !== p[1];
+        }
+        var snapped = -1, snappedDist = SNAP_PX;
+        for (var j = data.first; j < data.runs.length; j++) {
+            var d = Math.abs(screenX(j) - vx);
+            if (d <= snappedDist && hasChange(j)) { snapped = j; snappedDist = d; }
+        }
+        if (snapped >= 0 && !hasChange(runIdx)) {
+            runIdx = snapped;
+            run = data.runs[runIdx];
+            prev = runIdx > 0 ? data.runs[runIdx - 1] : null;
+        }
+
+        var runVx = px + ((run.x - data.xMin) / xRange) * pw;
+        guide.setAttribute("x1", runVx);
+        guide.setAttribute("x2", runVx);
+        guide.style.display = "";
+
+        dot.setAttribute("cx", runVx);
+        dot.setAttribute("cy", py + (1 - (run.v[best][0] / run.v[best][1])) * ph);
+        dot.setAttribute("fill", data.series[best].color);
+        dot.style.display = "";
+
+        var html = "<div style='font-weight:bold'>" + esc(run.sha.slice(0, 9)) + " (" + esc(run.d) + ")</div>";
+        if (run.msg) {
+            html += "<div style='margin-bottom:4px;white-space:nowrap;overflow:hidden;" +
+                "text-overflow:ellipsis'>" + esc(run.msg) + "</div>";
+        }
+        var pass = run.v[best][0], total = run.v[best][1];
+        html += "<div><span style='color:" + data.series[best].color + "'>\u25CF</span> " +
+            esc(data.series[best].name) + ": " + (100 * pass / total).toFixed(1) + "% (" +
+            pass.toLocaleString() + "/" + total.toLocaleString() + ")</div>";
+
+        // Change relative to the previous run
+        if (prev && prev.v[best] != null) {
+            var dPass = pass - prev.v[best][0];
+            var dPct = 100 * (pass / total - prev.v[best][0] / prev.v[best][1]);
+            var sign = dPass > 0 ? "+" : "";
+            var color = dPass > 0 ? "#2e7d32" : (dPass < 0 ? "#c62828" : "#666");
+            html += "<div style='color:" + color + "'>Change: " + sign +
+                dPass.toLocaleString() + " (" + sign + dPct.toFixed(2) + "%)</div>";
+        }
+        tip.innerHTML = html;
+        tip.style.display = "block";
+
+        var crect = container.getBoundingClientRect();
+        var cx = ev.clientX - crect.left, cy = ev.clientY - crect.top;
+        var left = cx + 14;
+        if (left + tip.offsetWidth > container.clientWidth) left = cx - tip.offsetWidth - 14;
+        tip.style.left = left + "px";
+        tip.style.top = (cy + 14) + "px";
+    });
+    svg.addEventListener("mouseleave", hide);
+});

--- a/static/wpt-history-tooltip.js
+++ b/static/wpt-history-tooltip.js
@@ -69,11 +69,13 @@ document.querySelectorAll("script[data-wpt-history-data]").forEach(function (dat
         var run = data.runs[runIdx];
         var prev = runIdx > 0 ? data.runs[runIdx - 1] : null;
 
-        // Pick the single series whose line is vertically nearest the cursor
+        // Pick the single series whose line is vertically nearest the cursor.
+        // Percentages use the latest run's subtest total as the denominator,
+        // matching the plotted lines.
         var best = -1, bestDist = Y_THRESHOLD;
         for (var i = 0; i < data.series.length; i++) {
-            if (run.v[i] == null) continue;
-            var sy = py + (1 - (run.v[i][0] / run.v[i][1])) * ph;
+            if (run.v[i] == null || !data.series[i].latest) continue;
+            var sy = py + (1 - (run.v[i][0] / data.series[i].latest)) * ph;
             var dist = Math.abs(sy - vy);
             if (dist < bestDist) { best = i; bestDist = dist; }
         }
@@ -106,7 +108,7 @@ document.querySelectorAll("script[data-wpt-history-data]").forEach(function (dat
         guide.style.display = "";
 
         dot.setAttribute("cx", runVx);
-        dot.setAttribute("cy", py + (1 - (run.v[best][0] / run.v[best][1])) * ph);
+        dot.setAttribute("cy", py + (1 - (run.v[best][0] / data.series[best].latest)) * ph);
         dot.setAttribute("fill", data.series[best].color);
         dot.style.display = "";
 
@@ -115,7 +117,7 @@ document.querySelectorAll("script[data-wpt-history-data]").forEach(function (dat
             html += "<div style='margin-bottom:4px;white-space:nowrap;overflow:hidden;" +
                 "text-overflow:ellipsis'>" + esc(run.msg) + "</div>";
         }
-        var pass = run.v[best][0], total = run.v[best][1];
+        var pass = run.v[best][0], total = data.series[best].latest;
         html += "<div><span style='color:" + data.series[best].color + "'>\u25CF</span> " +
             esc(data.series[best].name) + ": " + (100 * pass / total).toFixed(1) + "% (" +
             pass.toLocaleString() + "/" + total.toLocaleString() + ")</div>";
@@ -123,7 +125,7 @@ document.querySelectorAll("script[data-wpt-history-data]").forEach(function (dat
         // Change relative to the previous run
         if (prev && prev.v[best] != null) {
             var dPass = pass - prev.v[best][0];
-            var dPct = 100 * (pass / total - prev.v[best][0] / prev.v[best][1]);
+            var dPct = 100 * ((pass - prev.v[best][0]) / total);
             var sign = dPass > 0 ? "+" : "";
             var color = dPass > 0 ? "#2e7d32" : (dPass < 0 ? "#c62828" : "#666");
             html += "<div style='color:" + color + "'>Change: " + sign +

--- a/static/wpt-history-tooltip.js
+++ b/static/wpt-history-tooltip.js
@@ -69,34 +69,40 @@ document.querySelectorAll("script[data-wpt-history-data]").forEach(function (dat
         var run = data.runs[runIdx];
         var prev = runIdx > 0 ? data.runs[runIdx - 1] : null;
 
-        // Pick the single series whose line is vertically nearest the cursor.
-        // Distance is measured to the line as drawn (interpolated between the
-        // runs bracketing the cursor) so steep jumps stay hoverable anywhere
-        // along their length. Percentages use the latest run's subtest total
-        // as the denominator, matching the plotted lines.
-        function lineYAtCursor(i) {
+        // Pick the single series whose drawn line is nearest the cursor.
+        // Distance is measured to the polyline's segments (2D point-to-segment
+        // distance) so steep, near-vertical jumps are hoverable anywhere along
+        // their length, not just near their endpoints.
+        function distToSegment(x, y, x1, y1, x2, y2) {
+            var dx = x2 - x1, dy = y2 - y1;
+            var len2 = dx * dx + dy * dy;
+            var t = len2 ? ((x - x1) * dx + (y - y1) * dy) / len2 : 0;
+            t = Math.max(0, Math.min(1, t));
+            return Math.hypot(x - (x1 + t * dx), y - (y1 + t * dy));
+        }
+        function seriesDist(i) {
             var runs = data.runs, latest = data.series[i].latest;
-            var before = -1, after = -1;
-            for (var j = data.first; j < runs.length; j++) {
-                if (runs[j].v[i] == null) continue;
-                if (runs[j].x <= data.xMin + ((vx - px) / pw) * xRange) before = j;
-                else { after = j; break; }
-            }
-            if (before < 0 && after < 0) return null;
-            if (before < 0) before = after;
-            if (after < 0) after = before;
             function yOf(j) { return py + (1 - runs[j].v[i][0] / latest) * ph; }
             function xOf(j) { return px + ((runs[j].x - data.xMin) / xRange) * pw; }
-            if (xOf(after) === xOf(before)) return yOf(before);
-            var t = (vx - xOf(before)) / (xOf(after) - xOf(before));
-            return yOf(before) + t * (yOf(after) - yOf(before));
+            // Consider only segments within a horizontal window of the cursor
+            var windowPx = Y_THRESHOLD;
+            var dist = Infinity, prevJ = -1;
+            for (var j = data.first; j < runs.length; j++) {
+                if (runs[j].v[i] == null) continue;
+                if (prevJ >= 0 && xOf(j) >= vx - windowPx && xOf(prevJ) <= vx + windowPx) {
+                    dist = Math.min(dist, distToSegment(vx, vy, xOf(prevJ), yOf(prevJ), xOf(j), yOf(j)));
+                } else if (prevJ < 0 && Math.abs(xOf(j) - vx) <= windowPx) {
+                    dist = Math.min(dist, Math.hypot(xOf(j) - vx, yOf(j) - vy));
+                }
+                if (xOf(j) > vx + windowPx) break;
+                prevJ = j;
+            }
+            return dist;
         }
         var best = -1, bestDist = Y_THRESHOLD;
         for (var i = 0; i < data.series.length; i++) {
             if (!data.series[i].latest) continue;
-            var sy = lineYAtCursor(i);
-            if (sy == null) continue;
-            var dist = Math.abs(sy - vy);
+            var dist = seriesDist(i);
             if (dist < bestDist) { best = i; bestDist = dist; }
         }
         if (best < 0 || run.v[best] == null) { hide(); return; }


### PR DESCRIPTION
## Summary

Adapts the site to the split summary layout from DioxusLabs/blitz-wpt-results#2 (merge that first) and adds browsable per-folder WPT pages, each with a history chart at the top. Supersedes #7 (branch kept as checkpoint).

**Data loading** (`src/wpt_history.rs`): the old monolithic `summary.json` + `commit-messages.json` loader is replaced with a per-group cache keyed by top-level folder. Each entry merges two fetches — shared `summary/runs.json` (date/shas/commit message, stored once) and `summary/areas/<group>.json` (`focus_areas` + score-tuple rows index-aligned with runs.json) — into a `WptHistory { focus_areas, runs: Vec<HistoryRun> }`. ETag revalidation per file; if only one file changed the other is refetched unconditionally so the aligned pair stays consistent. Same 30s-fresh / 30min stale-while-revalidate policy as the WPT report cache (extracted into `fresh_wpt_report()` / `fresh_wpt_history(group)` helpers in `main.rs`). Missing data degrades to "No history data available" instead of panicking.

**Folder pages**: new route `/status/wpt/{*folder}` (e.g. `/status/wpt/css/css-flexbox`) rendering `WptFolderPage`: breadcrumbs, a `FolderHistoryChart` (one line for the folder + up to 7 largest direct children), commit info, and a score table of the folder + its direct children. Area names in all score tables now link to their folder page. The main `/status/wpt` page gets the same chart for `css` at the top. Charts keep the existing behavior: range selector (1m/3m/6m/1y/all), SSR SVG, and the progressive-enhancement tooltip (commit sha/message from runs.json, pass counts, change vs previous run, hovered-line dot).

`/status/wpt/history` is retained, now driven by the `css` group data.

Verified locally against the new data branch: `/status/wpt`, `/status/wpt/css/css-flexbox`, `/status/wpt/css/CSS2/abspos`, `/status/wpt/history`, and 404 for unknown folders.

Link to Devin session: https://app.devin.ai/sessions/d987ba933f534a0a808775b74506f112
Requested by: @nicoburns