### PR TITLE
Mark mask-origin and mask-clip as supported

### DIFF
--- a/data/css-property-groups.json
+++ b/data/css-property-groups.json
@@ -86,8 +86,8 @@
       { "name": "mask-size", "status": "Yes" },
       { "name": "mask-composite", "status": "Yes" },
       { "name": "mask-mode", "status": "No" },
-      { "name": "mask-origin", "status": "No" },
-      { "name": "mask-clip", "status": "No" }
+      { "name": "mask-origin", "status": "Yes" },
+      { "name": "mask-clip", "status": "Yes" }
     ]
   },
   {


### PR DESCRIPTION
## Summary
Update the CSS property support registry so the Clipping & Masking group reports `mask-origin` and `mask-clip` as supported.

Link to Devin session: https://dioxus.staging.devinenterprise.com/sessions/ae9416191a2a4723be7680c5f021da93
Requested by: @nicoburns